### PR TITLE
Updates to account for changed names and addition of sub-directories for Yara-Rules.

### DIFF
--- a/clamav-unofficial-sigs.conf
+++ b/clamav-unofficial-sigs.conf
@@ -262,9 +262,12 @@ malwarepatrol_db="malwarepatrol.db" #LOW URLs containing of Viruses, Trojans, Wo
 # lines below.
 yararules_dbs="
 ### Yara Rules https://github.com/Yara-Rules/rules
+#
+# Some rules are now in sub-directories. To reference a file in a sub-directory
+# use subdir/file
 # LOW
-antidebug.yar #LOW anti debug and anti virtualization techniques used by malware 
-malicious_document.yar #LOW documents with malicious code
+antidebug_antivm.yar #LOW anti debug and anti virtualization techniques used by malware 
+Malicious_Documents/malicious_document.yar #LOW documents with malicious code
 # MED
 #packer.yar #MED well-known sofware packers
 # HIGH

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -1437,6 +1437,11 @@ if [ "$yararules_enabled" == "yes" ] ; then
   xshok_pretty_echo_and_log "Checking for yararules updates..."
   yararules_updates="0"
   for db_file in $yararules_dbs ; do
+   if echo $db_file|grep -q "/"; then
+    yr_dir="/"`echo $db_file | cut -d"/" -f1`
+    db_file=`echo $db_file | cut -d"/" -f2`
+   else yr_dir=""
+   fi
     if [ "$loop" = "1" ] ; then
       xshok_pretty_echo_and_log "---"      
     fi
@@ -1449,7 +1454,7 @@ if [ "$yararules_enabled" == "yes" ] ; then
     z_opt=""
   fi
   if curl $curl_proxy $curl_insecure $curl_output_level --connect-timeout "$curl_connect_timeout" \
-   --max-time "$curl_max_time" -L -R $z_opt -o $yararules_dir/$db_file "$yararules_url/$db_file"
+   --max-time "$curl_max_time" -L -R $z_opt -o $yararules_dir/$db_file "$yararules_url$yr_dir/$db_file"
    then
    loop="1"
    if ! cmp -s $yararules_dir/$db_file $clam_dbs/$db_file ; then


### PR DESCRIPTION
The Yara Rules repository at https://github.com/Yara-Rules/rules has been reorganized. The antidebug.yar file has been renamed antidebug_antivm.yar and the malicious_document.yar file has been moved to a Malicious_Documents subdirectory.

This patch changes the names in the config and changes the shell script to allow for names like sub-dir/file.yar in yararules_dbs and process them correctly. It won't handle two files of the same name in different sub-directories, but that doesn't seem to be an issue (yet).

In some sense, this may all be moot as at least some of the Yara Rules use features not yet supported by clamav, even 0.99.1, but as long as code exists to get these rules, it should work.