### PR TITLE
5.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ before_install:
 #install:
 #  - sh -e .travis/ci-setup.sh
 
-#script:
+script:
+  - sh -e .travis/ci-force.sh
 #  - sh -e .travis/ci-runtest.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+#language: shell
+
+cache:
+  directories:
+    - $HOME/.m2/repository
+ 
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install clamav-daemon -qq
+  - sudo freshclam
+  - sudo service clamav-daemon start
+
+#install:
+#  - sh -e .travis/ci-setup.sh
+
+#script:
+#  - sh -e .travis/ci-runtest.sh

--- a/.travis/ci-force.sh
+++ b/.travis/ci-force.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo .. forced OK

--- a/README.md
+++ b/README.md
@@ -77,7 +77,22 @@ Usage of free Linux Malware Detect clamav signatures: https://www.rfxn.com/proje
  - Enabled by default, no configuration required
 
 ## Change Log
-### Version 5.0.3 (updated 2016-03-27)
+### Version 5.0.4 (updated 2016-03-31)
+ - eXtremeSHOK.com Maintenance 
+ - Added/Updated OS configs: CentOS 7, FreeBSD, Slackware
+ - Added clamd_reload_opt to fix issues with centos7 conf
+ - Fix --remove-script should call remove_script() function by @IdahoPL
+ - Add OS specific settings to logrotate
+ - Increased default timeout values
+ - Attempt to Silence more output
+ - Create the log_file_path directory before we touch the file.
+ - Updated config file to remove the $work_dir varible from dir names
+ - Remove trailing / from directory names
+ - Initial support for Travis-Ci testing
+ - Fixed config option enable_logging -> logging_enabled
+ - Config updated to 56 due to changes
+
+### Version 5.0.3
  - eXtremeSHOK.com Maintenance 
  - Added OS configs: OpenSUSE, Archlinux, Gentoo, Raspbian, FreeBSD
  - Fixed config option enable_logging -> logging_enabled

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -291,16 +291,16 @@ if [ "$user_configuration_complete" != "yes" ] ; then
 fi
 
 # Assign the directories and remove trailing / (removes / and //)
-$work_dir=$(echo "$work_dir" | sed 's:/*$::')
+work_dir=$(echo "$work_dir" | sed 's:/*$::')
 
-$sanesecurity_dir=$(echo "$work_dir/$sanesecurity_dir" | sed 's:/*$::')
-$securiteinfo_dir=$(echo "$work_dir/$securiteinfo_dir" | sed 's:/*$::')
-$linuxmalwaredetect_dir=$(echo "$work_dir/$linuxmalwaredetect_dir" | sed 's:/*$::')
-$malwarepatrol_dir=$(echo "$work_dir/$malwarepatrol_dir" | sed 's:/*$::')
-$yararules_dir=$(echo "$work_dir/$yararules_dir" | sed 's:/*$::')
-$work_dir_configs=$(echo "$work_dir/$work_dir_configs" | sed 's:/*$::')
-$gpg_dir=$(echo "$work_dir/$gpg_dir" | sed 's:/*$::')
-$add_dir=$(echo "$work_dir/$add_dir" | sed 's:/*$::')
+sanesecurity_dir=$(echo "$work_dir/$sanesecurity_dir" | sed 's:/*$::')
+securiteinfo_dir=$(echo "$work_dir/$securiteinfo_dir" | sed 's:/*$::')
+linuxmalwaredetect_dir=$(echo "$work_dir/$linuxmalwaredetect_dir" | sed 's:/*$::')
+malwarepatrol_dir=$(echo "$work_dir/$malwarepatrol_dir" | sed 's:/*$::')
+yararules_dir=$(echo "$work_dir/$yararules_dir" | sed 's:/*$::')
+work_dir_configs=$(echo "$work_dir/$work_dir_configs" | sed 's:/*$::')
+gpg_dir=$(echo "$work_dir/$gpg_dir" | sed 's:/*$::')
+add_dir=$(echo "$work_dir/$add_dir" | sed 's:/*$::')
 
 ################################################################################
 

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -152,9 +152,9 @@ function help_and_usage () {
 }
 
 #Script Info
-version="5.0.3"
-minimum_required_config_version="55"
-version_date="27 March 2016"
+version="5.0.X"
+minimum_required_config_version="56"
+version_date="XX XXXXX 2016"
 
 #default config files
 config_dir="/etc/clamav-unofficial-sigs"
@@ -271,8 +271,6 @@ for config_file in "${config_files[@]}" ; do
 	fi
 done
 
-
-
 ## Make sure we have a readable config file
 if [ "$we_have_a_config" == "0" ] ; then
 	xshok_pretty_echo_and_log "ERROR: Config file/s could NOT be read/loaded" "="
@@ -291,6 +289,16 @@ if [ "$user_configuration_complete" != "yes" ] ; then
 	xshok_pretty_echo_and_log "Please review the script configuration files."
 	exit 1
 fi
+
+# Assign the directories
+sanesecurity_dir="$work_dir/$sanesecurity_dir"
+securiteinfo_dir="$work_dir/$securiteinfo_dir"
+linuxmalwaredetect_dir="$work_dir/$linuxmalwaredetect_dir"
+malwarepatrol_dir="$work_dir/$malwarepatrol_dir"
+yararules_dir="$work_dir/$yararules_dir"
+work_dir_configs="$work_dir/$work_dir_configs"
+gpg_dir="$work_dir/$gpg_dir"
+add_dir="$work_dir/$add_dir"
 
 
 ################################################################################

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -693,7 +693,12 @@ clamscan_reload_dbs (){
 				xshok_pretty_echo_and_log "Update(s) detected, reloading ClamAV databases" "="
 			fi
 
-			myresult=`clamdscan --reload 2>&1`
+			if [ -z "$clamd_reload_opt" ] ; then    
+				myresult=`clamdscan --reload 2>&1`
+			else
+				myresult=`$clamd_reload_opt 2>&1`
+			fi
+
 			if [[ "$myresult" =~ "ERROR" ]] ; then
 				xshok_pretty_echo_and_log "ERROR: Failed to reload, trying again" "-"
 				if [ -r "$clamd_pid" ] ; then

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -290,16 +290,17 @@ if [ "$user_configuration_complete" != "yes" ] ; then
 	exit 1
 fi
 
-# Assign the directories
-sanesecurity_dir="$work_dir/$sanesecurity_dir"
-securiteinfo_dir="$work_dir/$securiteinfo_dir"
-linuxmalwaredetect_dir="$work_dir/$linuxmalwaredetect_dir"
-malwarepatrol_dir="$work_dir/$malwarepatrol_dir"
-yararules_dir="$work_dir/$yararules_dir"
-work_dir_configs="$work_dir/$work_dir_configs"
-gpg_dir="$work_dir/$gpg_dir"
-add_dir="$work_dir/$add_dir"
+# Assign the directories and remove trailing / (removes / and //)
+$work_dir=$(echo "$work_dir" | sed 's:/*$::')
 
+$sanesecurity_dir=$(echo "$work_dir/$sanesecurity_dir" | sed 's:/*$::')
+$securiteinfo_dir=$(echo "$work_dir/$securiteinfo_dir" | sed 's:/*$::')
+$linuxmalwaredetect_dir=$(echo "$work_dir/$linuxmalwaredetect_dir" | sed 's:/*$::')
+$malwarepatrol_dir=$(echo "$work_dir/$malwarepatrol_dir" | sed 's:/*$::')
+$yararules_dir=$(echo "$work_dir/$yararules_dir" | sed 's:/*$::')
+$work_dir_configs=$(echo "$work_dir/$work_dir_configs" | sed 's:/*$::')
+$gpg_dir=$(echo "$work_dir/$gpg_dir" | sed 's:/*$::')
+$add_dir=$(echo "$work_dir/$add_dir" | sed 's:/*$::')
 
 ################################################################################
 

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -85,6 +85,7 @@ function xshok_pretty_echo_and_log () { #"string" "repeating" "count" "type"
 	# handle logging
 	if [ "$logging_enabled" = "yes" ] ; then
 		if [ ! -e "$log_file_path/$log_file_name" ] ; then
+				mkdir -p "$log_file_path" 2>/dev/null
 		    touch "$log_file_path/$log_file_name" 2>/dev/null
 		fi
 		if [ ! -w "$log_file_path/$log_file_name" ] ; then
@@ -271,6 +272,9 @@ for config_file in "${config_files[@]}" ; do
 	fi
 done
 
+# Assign the log_file_path earlier and remove trailing / (removes / and //)
+log_file_path=$(echo "$log_file_path" | sed 's:/*$::')
+
 ## Make sure we have a readable config file
 if [ "$we_have_a_config" == "0" ] ; then
 	xshok_pretty_echo_and_log "ERROR: Config file/s could NOT be read/loaded" "="
@@ -292,7 +296,6 @@ fi
 
 # Assign the directories and remove trailing / (removes / and //)
 work_dir=$(echo "$work_dir" | sed 's:/*$::')
-
 sanesecurity_dir=$(echo "$work_dir/$sanesecurity_dir" | sed 's:/*$::')
 securiteinfo_dir=$(echo "$work_dir/$securiteinfo_dir" | sed 's:/*$::')
 linuxmalwaredetect_dir=$(echo "$work_dir/$linuxmalwaredetect_dir" | sed 's:/*$::')

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -153,9 +153,9 @@ function help_and_usage () {
 }
 
 #Script Info
-version="5.0.X"
+version="5.0.4"
 minimum_required_config_version="56"
-version_date="XX XXXXX 2016"
+version_date="31 March 2016"
 
 #default config files
 config_dir="/etc/clamav-unofficial-sigs"

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -806,7 +806,7 @@ while true; do
 		-g | --gpg-verify ) gpg_verify_specific_sanesecurity_database_file; exit; break ;;
 		-i | --information ) output_system_configuration_information; exit; break ;;
 		-m | --make-database ) make_signature_database_from_ascii_file; exit; break ;;
-		-r | --remove-script ) make_signature_database_from_ascii_file; exit; break ;;
+		-r | --remove-script ) remove_script; exit; break ;;
 		-t | --test-database ) clamscan_integrity_test_specific_database_file; exit; break ;;
 		-o | --output-triggered ) output_signatures_triggered_during_ham_directory_scan; exit; break ;;
 		-w | --whitelist ) add_signature_whitelist_entry; exit; break ;;

--- a/config/master.conf
+++ b/config/master.conf
@@ -389,6 +389,6 @@ yararules_url="https://raw.githubusercontent.com/Yara-Rules/rules/master/"
 
 # ========================
 # do not edit
-config_version="55"
+config_version="56"
 
 # https://eXtremeSHOK.com ##############################################################

--- a/config/master.conf
+++ b/config/master.conf
@@ -326,14 +326,14 @@ max_sleep_time="600"   # Default maximum is 600 seconds (10 minutes).
 # Set rsync connection and data transfer timeout limits in seconds.
 # The defaults settings here are reasonable, only change if you are
 # experiencing timeout issues.
-rsync_connect_timeout="30"
-rsync_max_time="90"
+rsync_connect_timeout="60"
+rsync_max_time="180"
 
 # Set curl connection and data transfer timeout limits in seconds.
 # The defaults settings here are reasonable, only change if you are
 # experiencing timeout issues.
-curl_connect_timeout="30"
-curl_max_time="90"
+curl_connect_timeout="60"
+curl_max_time="180"
 
 # Set working directory paths (edit to meet your own needs). If these
 # directories do not exist, the script will attempt to create them.

--- a/config/master.conf
+++ b/config/master.conf
@@ -307,10 +307,11 @@ enable_random="yes"
 min_sleep_time="60"    # Default minimum is 60 seconds (1 minute).
 max_sleep_time="600"   # Default maximum is 600 seconds (10 minutes).
 
-# Set the clamd_restart_opt if the "reload_dbs" variable above is set
 # Command to do a full clamd service stop/start
-
 #clamd_restart_opt="service clamd restart"
+
+# Custom Command to fo a full clamd reload, this defaults to "clamdscan --reload" when not set
+#clamd_reload_opt="clamdscan --reload"
 
 # If running clamd in "LocalSocket" mode (*NOT* in TCP/IP mode), and
 # either "SOcket Cat" (socat) or the "IO::Socket::UNIX" perl module

--- a/config/master.conf
+++ b/config/master.conf
@@ -337,15 +337,16 @@ curl_max_time="180"
 
 # Set working directory paths (edit to meet your own needs). If these
 # directories do not exist, the script will attempt to create them.
+# Always located inside the work_dir, do not add /
 # Sub-directory names:
-sanesecurity_dir="$work_dir/dbs-ss"        # Sanesecurity sub-directory
-securiteinfo_dir="$work_dir/dbs-si"        # SecuriteInfo sub-directory 
-linuxmalwaredetect_dir="$work_dir/dbs-lmd"      # Linux Malware Detect sub-directory 
-malwarepatrol_dir="$work_dir/dbs-mbl"      # MalwarePatrol sub-directory 
-yararules_dir="$work_dir/dbs-yara"      # Yara-Rules sub-directory 
-work_dir_configs="$work_dir/configs"   # Script configs sub-directory
-gpg_dir="$work_dir/gpg-key"      # Sanesecurity GPG Key sub-directory
-add_dir="$work_dir/dbs-add"      # User defined databases sub-directory
+sanesecurity_dir="dbs-ss"        # Sanesecurity sub-directory
+securiteinfo_dir="dbs-si"        # SecuriteInfo sub-directory 
+linuxmalwaredetect_dir="dbs-lmd"      # Linux Malware Detect sub-directory 
+malwarepatrol_dir="dbs-mbl"      # MalwarePatrol sub-directory 
+yararules_dir="dbs-yara"      # Yara-Rules sub-directory 
+work_dir_configs="configs"   # Script configs sub-directory
+gpg_dir="gpg-key"      # Sanesecurity GPG Key sub-directory
+add_dir="dbs-add"      # User defined databases sub-directory
 
 # If you would like to make a backup copy of the current running database
 # file before updating, leave the following variable set to "yes" and a

--- a/config/os.centos7.conf
+++ b/config/os.centos7.conf
@@ -30,6 +30,8 @@ clam_dbs="/var/lib/clamav"
 
 clamd_pid="/var/run/clamav/clamd.pid"
 
-clamd_restart_opt="systemctl restart clamd@scan"
+clamd_restart_opt="systemctl restart clamd"
 
 #clamd_socket="/var/run/clamd.socket"
+
+clamd_reload_opt="clamdscan --config-file=/etc/clamd.d/scan.conf --reload"

--- a/config/os.centos7.conf
+++ b/config/os.centos7.conf
@@ -22,16 +22,17 @@
 # Rename to os.conf to enable this file
 ################################################################################
 
-# RHEL/CentOS 7
+# RHEL/CentOS 7, using ClamAV packages from EPEL
+
 clam_user="clamupdate"
 clam_group="clamupdate"
 
 clam_dbs="/var/lib/clamav"
 
-clamd_pid="/var/run/clamav/clamd.pid"
+clamd_pid="/var/run/clamd.scan/clamd.pid"
 
-clamd_restart_opt="systemctl restart clamd"
+clamd_restart_opt="systemctl restart clamd@scan"
 
-#clamd_socket="/var/run/clamd.socket"
+#clamd_socket="/var/run/clamd.scan/clamd.sock"
 
 clamd_reload_opt="clamdscan --config-file=/etc/clamd.d/scan.conf --reload"

--- a/config/os.freebsd.conf
+++ b/config/os.freebsd.conf
@@ -37,3 +37,6 @@ log_file_path="/var/log/clamav"
 clamd_restart_opt="service clamav-clamd reload"
 
 #clamd_socket="/var/run/clamav/clamd.sock"
+
+pkg_mgr="FreeBSD ports"
+pkg_rm="pkg remove"

--- a/config/os.slackware.conf
+++ b/config/os.slackware.conf
@@ -1,0 +1,37 @@
+# This file contains os configuration settings for clamav-unofficial-sigs.sh
+###################
+# This is property of eXtremeSHOK.com
+# You are free to use, modify and distribute, however you may not remove this notice.
+# Copyright (c) Adrian Jon Kriel :: admin@extremeshok.com
+##################
+#
+# Script updates can be found at: https://github.com/extremeshok/clamav-unofficial-sigs
+# 
+# Originially based on: 
+# Script provide by Bill Landry (unofficialsigs@gmail.com).
+#
+# License: BSD (Berkeley Software Distribution)
+#
+##################
+#
+# NOT COMPATIBLE WITH VERSION 3.XX / 4.XX CONFIG 
+#
+################################################################################
+# SEE MASTER.CONF FOR CONFIG EXPLAINATIONS
+################################################################################
+# Rename to os.conf to enable this file
+################################################################################
+
+# Slackware
+
+clam_user="clamav"
+clam_group="clamav"
+
+#clam_dbs="/var/lib/clamav"
+clam_dbs="/usr/local/share/clamav"
+
+clamd_pid="/var/run/clamav/clamd.pid"
+
+clamd_restart_opt="service clamd restart"
+
+#clamd_socket="/var/run/clamav/clamd.socket"

--- a/logrotate.d/clamav-unofficial-sigs
+++ b/logrotate.d/clamav-unofficial-sigs
@@ -20,8 +20,19 @@
      missingok
      notifempty
      compress
-# Redhat / CentOS 6
-     create 0644 clam clam
-# Debian / Ubuntu
+
+# UNCOMMENT the specific line for your OS
+
+## Debian / Ubuntu / Archlinux / Freebsd / Gentoo / Slackware / Raspbian
 #     create 0644 clamav clamav
+
+## Redhat / CentOS 6
+#     create 0644 clam clam
+
+## Redhat / CentOS 7
+#    create 0644 clamupdate clamupdate
+
+## OpenSUSE
+#    create 0644 vscan vscan
+
 }


### PR DESCRIPTION
 - eXtremeSHOK.com Maintenance 
 - Added/Updated OS configs: CentOS 7, FreeBSD, Slackware
 - Added clamd_reload_opt to fix issues with centos7 conf
 - Fix --remove-script should call remove_script() function by @IdahoPL
 - Add OS specific settings to logrotate
 - Increased default timeout values
 - Attempt to Silence more output
 - Create the log_file_path directory before we touch the file.
 - Updated config file to remove the $work_dir varible from dir names
 - Remove trailing / from directory names
 - Initial support for Travis-Ci testing
 - Fixed config option enable_logging -> logging_enabled
 - Config updated to 56 due to changes