### PR TITLE
Update Gentoo settings in os.gentoo.conf

### DIFF
--- a/config/os.gentoo.conf
+++ b/config/os.gentoo.conf
@@ -31,7 +31,7 @@ clam_dbs="/var/lib/clamav"
 
 clamd_pid="/var/run/clamav/clamd.pid"
 
-clamd_restart_opt="service clamd restart"
+clamd_restart_opt="clamdscan --reload"
 
 #clamd_socket="/var/run/clamav/clamd.sock"
 

--- a/config/os.gentoo.conf
+++ b/config/os.gentoo.conf
@@ -33,6 +33,6 @@ clamd_pid="/var/run/clamav/clamd.pid"
 
 clamd_restart_opt="clamdscan --reload"
 
-#clamd_socket="/var/run/clamav/clamd.sock"
+clamd_socket="/var/run/clamav/clamd.sock"
 
 # https://eXtremeSHOK.com ######################################################


### PR DESCRIPTION
Hello, I'm the Gentoo maintainer for the clamav-unofficial-sigs package. I just pushed out version 5.0.6, and the new os.gentoo.conf is really helpful. There are still two little changes that I'm having to make, though:

1. Set the reload command to something that will work on both OpenRC/systemd.
2. Uncomment the clamd_socket line (our clamav has the socket enabled by default).

These two commits make those changes. Afterwards, I should be able to install os.gentoo.conf without any changes. Note that anyone who wants to can install the package on Gentoo with a single command:

```bash
$ emerge clamav-unofficial-sigs
```