### PR TITLE
5.2.2

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,9 +1,10 @@
+---
 engines:
-	shellcheck:
+  shellcheck:
     enabled: true
   fixme:
     enabled: true
 ratings:
   paths: []
 exclude_paths:
-- config/
+  - .travis/

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,9 @@
+engines:
+	shellcheck:
+    enabled: true
+  fixme:
+    enabled: true
+ratings:
+  paths: []
+exclude_paths:
+- config/

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,3 +44,7 @@ install:
 
 script:
   - sudo sh -e .travis/ci-test.sh
+
+addons:
+  code_climate:
+    repo_token: 270be84579d01fcbe78b21b91719c2c55cd627f074c8abb83699a8319c980b60

--- a/INSTALL
+++ b/INSTALL
@@ -154,6 +154,9 @@ Usage: clamav-unofficial-sigs.sh [OPTION] [PATH|FILE]
 --check-clamav  If ClamD status check is enabled and the socket path is correctly
         specifiedthen test to see if clamd is running or not
 
+--install-all   Install and generate the cron, logroate and man files, autodetects the values
+         based on your config files
+
 --install-cron  Install and generate the cron file, autodetects the values
         based on your config files
 

--- a/INSTALL
+++ b/INSTALL
@@ -137,9 +137,6 @@ Usage: clamav-unofficial-sigs.sh [OPTION] [PATH|FILE]
         data strings, with one data string per line.  Additional
         information is provided when using this flag
 
--r, --remove-script     Remove the clamav-unofficial-sigs script and all of
-        its associated files and databases from the system
-
 -t, --test-database     Clamscan integrity test a specific database file
         eg: '-s filename.ext' (do not include file path)
 
@@ -163,8 +160,11 @@ Usage: clamav-unofficial-sigs.sh [OPTION] [PATH|FILE]
 --install-logrotate     Install and generate the logrotate file, autodetects the
         values based on your config files
 
- --install-man   Install and generate the man file, autodetects the
+--install-man   Install and generate the man file, autodetects the
          values based on your config files
+
+--remove-script     Remove the clamav-unofficial-sigs script and all of
+        its associated files and databases from the system
 
 ### Script updates can be found at: https://github.com/extremeshok/clamav-unofficial-sigs
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Usage of free Linux Malware Detect clamav signatures: https://www.rfxn.com/proje
 
 ## Change Log
 ### Version 5.2.2 (updated 2016-04-18)
- - eXtremeSHOK.com Maintenance 
+ - eXtremeSHOK.com Maintenance
+ - Added --install-all Install and generate the cron, logroate and man files, autodetects the values $oft based on your config files
  - Added functions: xshok_prompt_confirm, xshok_is_file, xshok_is_subdir
  - Replaced Y/N prompts with xshok_prompt_confirm
  - Added more warnings to remove_script and made it double confirmed
@@ -454,6 +455,9 @@ Usage: clamav-unofficial-sigs.sh [OPTION] [PATH|FILE]
 
 --check-clamav  If ClamD status check is enabled and the socket path is correctly
         specifiedthen test to see if clamd is running or not
+
+--install-all   Install and generate the cron, logroate and man files, autodetects the values
+         based on your config files
 
 --install-cron  Install and generate the cron file, autodetects the values
         based on your config files

--- a/README.md
+++ b/README.md
@@ -85,7 +85,17 @@ Usage of free Linux Malware Detect clamav signatures: https://www.rfxn.com/proje
  - Enabled by default, no configuration required
 
 ## Change Log
-### Version 5.2.1 (updated 2016-04-16)
+### Version 5.2.2 (updated 2016-04-18)
+ - eXtremeSHOK.com Maintenance 
+ - Added functions: xshok_prompt_confirm, xshok_is_file, xshok_is_subdir
+ - Replaced Y/N prompts with xshok_prompt_confirm
+ - Added more warnings to remove_script and made it double confirmed
+ - Remove_script will only remove work_dir if its a sub directory
+ - Remove_script will only remove files if they are files
+ - Removed -r switch, --remove-script needs to be used instead of both -r and --remove-script
+ - Fixed: remove_script not removing logrotate file, cron file, man file
+
+### Version 5.2.1
  - eXtremeSHOK.com Maintenance
  - Minor bugfix for Sanesecurity_sigtest.yara Sanesecurity_spam.yara files being removed incorrectly
  - Minor fix: yararulesproject_enabled not yararulesproject_enable
@@ -428,9 +438,6 @@ Usage: clamav-unofficial-sigs.sh [OPTION] [PATH|FILE]
         data strings, with one data string per line.  Additional
         information is provided when using this flag
 
--r, --remove-script     Remove the clamav-unofficial-sigs script and all of
-        its associated files and databases from the system
-
 -t, --test-database     Clamscan integrity test a specific database file
         eg: '-s filename.ext' (do not include file path)
 
@@ -454,8 +461,11 @@ Usage: clamav-unofficial-sigs.sh [OPTION] [PATH|FILE]
 --install-logrotate     Install and generate the logrotate file, autodetects the
         values based on your config files
 
- --install-man   Install and generate the man file, autodetects the
+--install-man   Install and generate the man file, autodetects the
          values based on your config files
+
+--remove-script     Remove the clamav-unofficial-sigs script and all of
+        its associated files and databases from the system
 
 ## Script updates can be found at: 
 ### https://github.com/extremeshok/clamav-unofficial-sigs

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # clamav-unofficial-sigs [![Build Status](https://travis-ci.org/extremeshok/clamav-unofficial-sigs.svg?branch=master)](https://travis-ci.org/extremeshok/clamav-unofficial-sigs)
+[![Code Climate](https://codeclimate.com/github/extremeshok/clamav-unofficial-sigs/badges/gpa.svg)](https://codeclimate.com/github/extremeshok/clamav-unofficial-sigs)
+[![Test Coverage](https://codeclimate.com/github/extremeshok/clamav-unofficial-sigs/badges/coverage.svg)](https://codeclimate.com/github/extremeshok/clamav-unofficial-sigs/coverage)
+[![Issue Count](https://codeclimate.com/github/extremeshok/clamav-unofficial-sigs/badges/issue_count.svg)](https://codeclimate.com/github/extremeshok/clamav-unofficial-sigs)
+
 ClamAV Unofficial Signatures Updater
 
 Github fork of the sourceforge hosted and non maintained utility.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Usage of free Linux Malware Detect clamav signatures: https://www.rfxn.com/proje
  - Added --install-all Install and generate the cron, logroate and man files, autodetects the values $oft based on your config files
  - Added functions: xshok_prompt_confirm, xshok_is_file, xshok_is_subdir
  - Replaced Y/N prompts with xshok_prompt_confirm
+ - Bug Fix for disabled databases being removed when the remove_disabled_databases is set to NO (default)
  - Added more warnings to remove_script and made it double confirmed
  - Remove_script will only remove work_dir if its a sub directory
  - Remove_script will only remove files if they are files

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -50,15 +50,15 @@ function perms () {
 
 # Function to prompt a user if they should complete an action with Y or N
 # usage: xshok_prompt_confirm
-# if [ xshok_prompt_confirm ]; then
+# if xshok_prompt_confirm; then
 # xshok_prompt_confirm && echo "accepted"
 # xshok_prompt_confirm && echo "yes" || echo "no"
 xshok_prompt_confirm () {
   while true; do
     read -r -p "${1:-Are you sure? [y/N]} " response
     case $response in
-      [yY]) echo ; return 0 ;;
-      [nN]) echo ;return 1 ;;
+      [yY]) return 0 ;;
+      [nN]) return 1 ;;
       *) printf " \033[31m %s \n\033[0m" "invalid input"
     esac 
   done  
@@ -553,7 +553,7 @@ function make_signature_database_from_ascii_file () {
 	- Line numbering will be done automatically by the script.
 	" | command sed 's/^          //g'
 	echo -n "Do you wish to continue? "
-	if [ `xshok_prompt_confirm` ] ; then
+	if xshok_prompt_confirm ; then
 
 		echo -n "Enter the source file as /path/filename: "
 		read source
@@ -595,7 +595,7 @@ function make_signature_database_from_ascii_file () {
 			echo "Clamscan reports database integrity tested good."
 
 			echo -n "Would you like to move '$db_file' into '$clam_dbs' and reload databases?"
-			if [ `xshok_prompt_confirm` ] ; then
+			if xshok_prompt_confirm ; then
 				if ! cmp -s "$path_file" "$clam_dbs/$db_file" ; then
 					if $rsync_bin -pcqt "$path_file" "$clam_dbs" ; then
 						perms chown -f $clam_user:$clam_group "$clam_dbs/$db_file"
@@ -629,51 +629,54 @@ function make_signature_database_from_ascii_file () {
 function remove_script () {
 	echo ""
 	if [ -n "$pkg_mgr" -a -n "$pkg_rm" ] ; then
-		echo "  This script (clamav-unofficial-sigs) was installed on the system"
-		echo "  via '$pkg_mgr', use '$pkg_rm' to remove the script"
-		echo "  and all of its associated files and databases from the system."
+		echo "This script (clamav-unofficial-sigs) was installed on the system via '$pkg_mgr'"
+		echo "use '$pkg_rm' to remove the script and all of its associated files and databases from the system."
 
 	else
-		echo "  Are you sure you want to remove the clamav-unofficial-sigs script and all of its"
-		echo -n "  associated files, third-party databases, and work directories from the system?"
-		if [ `xshok_prompt_confirm` ] ; then
-			if [ -r "$work_dir_work_configs/purge.txt" ] ; then
+		cron_file_full_path="$cron_dir/$cron_filename"
+		logrotate_file_full_path="$logrotate_dir/$logrotate_filename"
+		man_file_full_path="$man_dir/$man_filename"
+		
+		echo "This will remove the workdir ($work_dir), logrotate file ($logrotate_file_full_path), cron file ($cron_file_full_path), man file ($man_file_full_path)"
+		echo "Are you sure you want to remove the clamav-unofficial-sigs script and all of its associated files, third-party databases, and work directory from the system?"
+		if xshok_prompt_confirm ; then
+			echo "This can not be undone are you sure ?"
+			if xshok_prompt_confirm ; then
+				if [ -r "$work_dir_work_configs/purge.txt" ] ; then
 
-				for file in `cat $work_dir_work_configs/purge.txt` ; do
-					xshok_is_file "$file" && rm -f -- "$file"
-					echo "     Removed file: $file"
-				done
-				cron_file_full_path="$cron_dir/$cron_filename"
-				if [ -r "$cron_file_full_path" ] ; then
-					xshok_is_file "$cron_file_full_path" && rm -f "$cron_file_full_path"
-					echo "     Removed file: $cron_file_full_path"
-				fi
-				logrotate_file_full_path="$logrotate_dir/$logrotate_filename"
-				if [ -r "$logrotate_file_full_path" ] ; then
-					xshok_is_file "$logrotate_file_full_path" && rm -f "$logrotate_file_full_path"
-					echo "     Removed file: $logrotate_file_full_path"
-				fi
-				man_file_full_path="$man_dir/$man_filename"
-				if [ -r "$man_file_full_path" ] ; then
-					xshok_is_file "$man_file_full_path" && rm -f "$man_file_full_path"
-					echo "     Removed file: $man_file_full_path"
-				fi
-				
-				#rather keep the configs
-				#rm -f -- "$default_config" && echo "     Removed file: $default_config"
-				#rm -f -- "$0" && echo "     Removed file: $0"
-				xshok_is_subdir "$work_dir" && rm -rf -- "$work_dir" && echo "     Removed script working directories: $work_dir"
+					for file in `cat $work_dir_work_configs/purge.txt` ; do
+						xshok_is_file "$file" && rm -f -- "$file"
+						echo "     Removed file: $file"
+					done
+					if [ -r "$cron_file_full_path" ] ; then
+						xshok_is_file "$cron_file_full_path" && rm -f "$cron_file_full_path"
+						echo "     Removed file: $cron_file_full_path"
+					fi
+					if [ -r "$logrotate_file_full_path" ] ; then
+						xshok_is_file "$logrotate_file_full_path" && rm -f "$logrotate_file_full_path"
+						echo "     Removed file: $logrotate_file_full_path"
+					fi
+					if [ -r "$man_file_full_path" ] ; then
+						xshok_is_file "$man_file_full_path" && rm -f "$man_file_full_path"
+						echo "     Removed file: $man_file_full_path"
+					fi
+					
+					#rather keep the configs
+					#rm -f -- "$default_config" && echo "     Removed file: $default_config"
+					#rm -f -- "$0" && echo "     Removed file: $0"
+					xshok_is_subdir "$work_dir" && rm -rf -- "$work_dir" && echo "     Removed script working directories: $work_dir"
 
-				echo "  The clamav-unofficial-sigs script and all of its associated files, third-party"
-				echo "  databases, and work directories have been successfully removed from the system."
+					echo "  The clamav-unofficial-sigs script and all of its associated files, third-party"
+					echo "  databases, and work directories have been successfully removed from the system."
 
+				else
+					echo "  Cannot locate 'purge.txt' file in $work_dir_work_configs."
+					echo "  Files and signature database will need to be removed manually."
+				fi
 			else
-				echo "  Cannot locate 'purge.txt' file in $work_dir_work_configs."
-				echo "  Files and signature database will need to be removed manually."
-
-			fi
+				echo "Aborted"
 		else
-			help_and_usage
+			echo "Aborted"
 		fi
 	fi
 }
@@ -952,8 +955,6 @@ $ofs -i, --information $ofe Output system and configuration information for $oft
 $ofb 
 $ofs -m, --make-database $ofe Make a signature database from an ascii file containing $oft data strings, with one data string per line.  Additional $oft information is provided when using this flag
 $ofb 
-$ofs -r, --remove-script $ofe Remove the clamav-unofficial-sigs script and all of $oft its associated files and databases from the system
-$ofb 
 $ofs -t, --test-database $ofe Clamscan integrity test a specific database file $oft eg: '-s filename.ext' (do not include file path)
 $ofb 
 $ofs -o, --output-triggered $ofe If HAM directory scanning is enabled in the script's $oft configuration file, then output names of any third-party $oft signatures that triggered during the HAM directory scan
@@ -967,6 +968,8 @@ $ofb
 $ofs --install-logrotate $ofe Install and generate the logrotate file, autodetects the $oft values based on your config files
 $ofb 
 $ofs --install-man $ofe Install and generate the man file, autodetects the $oft values based on your config files
+$ofb 
+$ofs --remove-script $ofe Remove the clamav-unofficial-sigs script and all of $oft its associated files and databases from the system
 $ofb 
 EOF
 	` #this is very important...
@@ -986,8 +989,8 @@ EOF
 ################################################################################
 
 #Script Info
-script_version="5.2.1"
-script_version_date="16 April 2016"
+script_version="5.2.2"
+script_version_date="18 April 2016"
 minimum_required_config_version="62"
 minimum_yara_clamav_version="0.99"
 
@@ -1273,7 +1276,6 @@ while true; do
 		-g | --gpg-verify ) gpg_verify_specific_sanesecurity_database_file; exit; break ;;
 		-i | --information ) output_system_configuration_information; exit; break ;;
 		-m | --make-database ) make_signature_database_from_ascii_file; exit; break ;;
-		-r | --remove-script ) remove_script; exit; break ;;
 		-t | --test-database ) clamscan_integrity_test_specific_database_file; exit; break ;;
 		-o | --output-triggered ) output_signatures_triggered_during_ham_directory_scan; exit; break ;;
 		-w | --whitelist ) add_signature_whitelist_entry; exit; break ;;
@@ -1281,6 +1283,7 @@ while true; do
 		--install-cron ) install_cron; exit; break ;;
 		--install-logrotate ) install_logrotate; exit; break ;;
 		--install-man ) install_man; exit; break ;;
+		--remove-script ) remove_script; exit; break ;;
 		* ) break ;;
 	esac
 done

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -57,8 +57,8 @@ xshok_prompt_confirm () {
   while true; do
     read -r -p "${1:-Are you sure? [y/N]} " response
     case $response in
-      [yY]) return 0 ;;
-      [nN]) return 1 ;;
+      [yY]) echo ; return 0 ;;
+      [nN]) echo ;return 1 ;;
       *) printf " \033[31m %s \n\033[0m" "invalid input"
     esac 
   done  
@@ -553,7 +553,7 @@ function make_signature_database_from_ascii_file () {
 	- Line numbering will be done automatically by the script.
 	" | command sed 's/^          //g'
 	echo -n "Do you wish to continue? "
-	if [ xshok_prompt_confirm ] ; then
+	if [ `xshok_prompt_confirm` ] ; then
 
 		echo -n "Enter the source file as /path/filename: "
 		read source
@@ -595,7 +595,7 @@ function make_signature_database_from_ascii_file () {
 			echo "Clamscan reports database integrity tested good."
 
 			echo -n "Would you like to move '$db_file' into '$clam_dbs' and reload databases?"
-			if [ xshok_prompt_confirm ] ; then
+			if [ `xshok_prompt_confirm` ] ; then
 				if ! cmp -s "$path_file" "$clam_dbs/$db_file" ; then
 					if $rsync_bin -pcqt "$path_file" "$clam_dbs" ; then
 						perms chown -f $clam_user:$clam_group "$clam_dbs/$db_file"
@@ -636,7 +636,7 @@ function remove_script () {
 	else
 		echo "  Are you sure you want to remove the clamav-unofficial-sigs script and all of its"
 		echo -n "  associated files, third-party databases, and work directories from the system?"
-		if [ xshok_prompt_confirm ] ; then
+		if [ `xshok_prompt_confirm` ] ; then
 			if [ -r "$work_dir_work_configs/purge.txt" ] ; then
 
 				for file in `cat $work_dir_work_configs/purge.txt` ; do

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -195,7 +195,8 @@ function clamav_files () {
 	fi
 }
 
-
+# Function to manage the databases and allow multi-dimensions as well as global overrides
+# since the datbases are basically a multi-dimentional associative arrays in bash
 function xshok_database () { #database #override
 	true ;
 }
@@ -1525,7 +1526,7 @@ if [ "$malwarepatrol_enabled" == "yes" ] ; then
 		clamav_files
 	fi
 fi
-if [ "$|yararulesproject_enabled" == "yes" ] ; then
+if [ "$yararulesproject_enabled" == "yes" ] ; then
 	if [ -n "$yararulesproject_dbs" ] ; then
 		for db in $yararulesproject_dbs ; do
 			if echo $db|grep -q "/"; then
@@ -1621,17 +1622,15 @@ fi
 # Check and save current system time since epoch for time related database downloads.
 # However, if unsuccessful, issue a warning that we cannot calculate times since epoch.
 if [ -n "$securiteinfo_dbs" -o -n "malwarepatrol_db" ] ; then
-	if [ `date +%s` -gt 0 2>/dev/null ] ; then
-		current_time=`date +%s`
-	else
-		if [ `perl -le print+time 2>/dev/null` ] ; then
-			current_time=`perl -le print+time`
-		fi
+	current_time=$(date +%s 2>/dev/null)
+	if [ $current_time -le 0 ] ; then
+		current_time=$(perl -le print+time 2>/dev/null)
 	fi
-else
-	xshok_pretty_echo_and_log "WARNING: No support for 'date +%s' or 'perl' was not found , SecuriteInfo and MalwarePatrol updates bypassed" "="
-	securiteinfo_dbs=""
-	malwarepatrol_db=""
+	if [ $current_time -le 0 ] ; then
+		xshok_pretty_echo_and_log "WARNING: No support for 'date +%s' or 'perl' was not found , SecuriteInfo and MalwarePatrol updates bypassed" "="
+		securiteinfo_dbs=""
+		malwarepatrol_db=""
+	fi
 fi
 
 ################################################################
@@ -2229,7 +2228,7 @@ fi
 ##############################################################################################################################################
 # Check for updated yararulesproject database files every set number of hours as defined in the "USER CONFIGURATION" section of this script 
 ##############################################################################################################################################
-if [ "$|yararulesproject_enabled" == "yes" ] ; then
+if [ "$yararulesproject_enabled" == "yes" ] ; then
 	if [ -n "$yararulesproject_dbs" ] ; then
 		if [ `xshok_array_count "$yararulesproject_dbs"` -lt "1" ] ; then
 			xshok_pretty_echo_and_log "Failed yararulesproject_dbs config is invalid or not defined - SKIPPING"

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -1545,22 +1545,23 @@ if [ "$additional_enabled" == "yes" ] ; then
 fi
 
 # Remove 3rd-party databases and/or backup files that are no longer being used.
-sort "$current_tmp" > "$current_dbs" 2>/dev/null
-rm -f "$current_tmp"
-db_changes="$work_dir_work_configs/db-changes.txt"
-if [ ! -s "$previous_dbs" ] ; then
-	cp -f "$current_dbs" "$previous_dbs" 2>/dev/null
-fi
-diff "$current_dbs" "$previous_dbs" 2>/dev/null | grep '>' | awk '{print $2}' > "$db_changes"
-if [ -r "$db_changes" ] ; then
-	if grep -vq "bak" $db_changes 2>/dev/null ; then
-		do_clamd_reload=2
+if [ "$remove_disabled_databases" == "yes" ] ; then
+	sort "$current_tmp" > "$current_dbs" 2>/dev/null
+	rm -f "$current_tmp"
+	db_changes="$work_dir_work_configs/db-changes.txt"
+	if [ ! -s "$previous_dbs" ] ; then
+		cp -f "$current_dbs" "$previous_dbs" 2>/dev/null
 	fi
-
-	for file in `cat $db_changes` ; do
-		rm -f -- "$file"
-		xshok_pretty_echo_and_log "File removed: $file"
-	done
+	diff "$current_dbs" "$previous_dbs" 2>/dev/null | grep '>' | awk '{print $2}' > "$db_changes"
+	if [ -r "$db_changes" ] ; then
+		if grep -vq "bak" $db_changes 2>/dev/null ; then
+			do_clamd_reload=2
+		fi
+		for file in `cat $db_changes` ; do
+			rm -f -- "$file"
+			xshok_pretty_echo_and_log "Unused/Disabled file removed: $file"
+		done
+	fi
 fi
 
 # Create "purge.txt" file for package maintainers to support package uninstall.

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -196,6 +196,10 @@ function clamav_files () {
 }
 
 
+function xshok_database () { #database #override
+	true ;
+}
+
 ################################################################################
 # ADDITIONAL PROGRAM FUNCTIONS
 ################################################################################
@@ -1482,10 +1486,6 @@ fi
 # Create $current_dbsfiles containing lists of current and previously active 3rd-party databases
 # so that databases and/or backup files that are no longer being used can be removed.
 current_tmp="$work_dir_work_configs/current-dbs.tmp"
-current_dbs="$work_dir_work_configs/current-dbs.txt"
-previous_dbs="$work_dir_work_configs/previous-dbs.txt"
-sort "$current_dbs" > "$previous_dbs" 2>/dev/null
-rm -f "$current_dbs"
 
 if [ "$sanesecurity_enabled" == "yes" ] ; then
 	# Create the Sanesecurity rsync "include" file (defines which files to download).
@@ -1546,6 +1546,11 @@ fi
 
 # Remove 3rd-party databases and/or backup files that are no longer being used.
 if [ "$remove_disabled_databases" == "yes" ] ; then
+	current_dbs="$work_dir_work_configs/current-dbs.txt"
+	previous_dbs="$work_dir_work_configs/previous-dbs.txt"
+	sort "$current_dbs" > "$previous_dbs" 2>/dev/null
+	rm -f "$current_dbs"
+
 	sort "$current_tmp" > "$current_dbs" 2>/dev/null
 	rm -f "$current_tmp"
 	db_changes="$work_dir_work_configs/db-changes.txt"

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -675,6 +675,7 @@ function remove_script () {
 				fi
 			else
 				echo "Aborted"
+			fi
 		else
 			echo "Aborted"
 		fi

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -964,6 +964,8 @@ $ofs -w, --whitelist $ofe Adds a signature whitelist entry in the newer ClamAV I
 $ofb 
 $ofs --check-clamav $ofe If ClamD status check is enabled and the socket path is correctly $oft specifiedthen test to see if clamd is running or not
 $ofb 
+$ofs --install-all $ofe Install and generate the cron, logroate and man files, autodetects the values $oft based on your config files
+$ofb
 $ofs --install-cron $ofe Install and generate the cron file, autodetects the values $oft based on your config files
 $ofb 
 $ofs --install-logrotate $ofe Install and generate the logrotate file, autodetects the $oft values based on your config files
@@ -1281,6 +1283,7 @@ while true; do
 		-o | --output-triggered ) output_signatures_triggered_during_ham_directory_scan; exit; break ;;
 		-w | --whitelist ) add_signature_whitelist_entry; exit; break ;;
 		--check-clamav ) check_clamav; exit; break ;;
+		--install-all ) install_cron; install_logrotate; install_man; exit; break ;;
 		--install-cron ) install_cron; exit; break ;;
 		--install-logrotate ) install_logrotate; exit; break ;;
 		--install-man ) install_man; exit; break ;;

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -48,6 +48,41 @@ function perms () {
 	fi
 }
 
+# Function to prompt a user if they should complete an action with Y or N
+xshok_prompt_confirm () {
+  while true; do
+    read -r -p "${1:-Are you sure? [y/N]} " response
+    case $response in
+      [yY]) echo ; return 0 ;;
+      [nN]) echo ; return 1 ;;
+      *) printf " \033[31m %s \n\033[0m" "invalid input"
+    esac 
+  done  
+}
+
+# Function to check if its a file, otherwise return false
+xshok_is_file () { #"filepath"
+	filepath=$1
+  if [ -f "${filepath}" ]; then
+  	return 0 ;;
+  else
+  	return 1 ;;	#not a file
+  fi 
+}
+
+# Function to check if its a subdir, otherwise return false
+xshok_is_subdir () {
+	filepath=$1
+	res="${filepath//[^\/]}"
+	echo "${#res}"
+	if [ "${#res}" -gt 1 ]; then]
+		return 0 ;;
+	else
+		return 1 ;;	#not a subdir
+	fi
+}
+
+
 # Function to create a dir and set the ownership
 function xshok_mkdir_ownership () { #"path"
 	mkdir -p "$1" 2>/dev/null
@@ -161,17 +196,6 @@ function install_man (){
 	echo "Generating man file for install...."
 	
 	#Use defined varibles or attempt to use default varibles
-	if [ ! -n "$man_dir" ] ; then
-		man_dir="/usr/share/man/man8"
-	fi
-	if [ ! -n "$man_filename" ] ; then
-		man_filename="clamav-unofficial-sigs.8"
-	fi	
-	if [ ! -n "$man_log_file_full_path" ] ; then
-		man_log_file_full_path="$log_file_path/$log_file_name"
-	fi
-
-	man_dir=$(echo "$man_dir" | sed 's:/*$::')
 
 	if [ ! -e "$man_dir/$man_filename" ] ; then
 		mkdir -p "$man_dir"
@@ -233,12 +257,7 @@ function install_logrotate (){
 	echo "Generating logrotate file for install...."
 	
 	#Use defined varibles or attempt to use default varibles
-	if [ ! -n "$logrotate_dir" ] ; then
-		logrotate_dir="/etc/logrotate.d"
-	fi
-	if [ ! -n "$logrotate_filename" ] ; then
-		logrotate_filename="clamav-unofficial-sigs"
-	fi	
+
 	if [ ! -n "$logrotate_user" ] ; then
 		logrotate_user="$clam_user";
 	fi
@@ -249,7 +268,6 @@ function install_logrotate (){
 		logrotate_log_file_full_path="$log_file_path/$log_file_name"
 	fi
 
-	logrotate_dir=$(echo "$logrotate_dir" | sed 's:/*$::')
 
 	if [ ! -e "$logrotate_dir/$logrotate_filename" ] ; then
 		mkdir -p "$logrotate_dir"
@@ -305,12 +323,6 @@ function install_cron (){
 	echo "Generating cron file for install...."
 	
 	#Use defined varibles or attempt to use default varibles
-	if [ ! -n "$cron_dir" ] ; then
-		cron_dir="/etc/cron.d"
-	fi
-	if [ ! -n "$cron_filename" ] ; then
-		cron_filename="clamav-unofficial-sigs"
-	fi	
 	if [ ! -n "$cron_minute" ] ; then
 		cron_minute=$[ ( $RANDOM % 59 )  + 1 ];
 	fi
@@ -330,7 +342,7 @@ function install_cron (){
 		cron_script_full_path="$cron_script_dir/$cron_script_name"
 	fi
 
-	cron_dir=$(echo "$cron_dir" | sed 's:/*$::')
+	
 
 	if [ ! -e "$cron_dir/$cron_filename" ] ; then
 		mkdir -p "$cron_dir"
@@ -1178,6 +1190,31 @@ else
 	work_dir_gpg=$(echo "$work_dir_gpg" | sed 's:/*$::')
 fi
 
+#	Assign defaults if not defined
+if [ ! -n "$cron_dir" ] ; then
+	cron_dir="/etc/cron.d"
+fi
+cron_dir=$(echo "$cron_dir" | sed 's:/*$::')
+if [ ! -n "$cron_filename" ] ; then
+	cron_filename="clamav-unofficial-sigs"
+fi
+if [ ! -n "$logrotate_dir" ] ; then
+	logrotate_dir="/etc/logrotate.d"
+fi
+logrotate_dir=$(echo "$logrotate_dir" | sed 's:/*$::')
+if [ ! -n "$logrotate_filename" ] ; then
+	logrotate_filename="clamav-unofficial-sigs"
+fi	
+if [ ! -n "$man_dir" ] ; then
+	man_dir="/usr/share/man/man8"
+fi
+man_dir=$(echo "$man_dir" | sed 's:/*$::')
+if [ ! -n "$man_filename" ] ; then
+	man_filename="clamav-unofficial-sigs.8"
+fi	
+if [ ! -n "$man_log_file_full_path" ] ; then
+	man_log_file_full_path="$log_file_path/$log_file_name"
+fi
 
 ### SANITY checks
 #Check default Binaries & Commands are defined

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -195,6 +195,7 @@ function clamav_files () {
 	fi
 }
 
+
 ################################################################################
 # ADDITIONAL PROGRAM FUNCTIONS
 ################################################################################
@@ -1523,7 +1524,7 @@ if [ "$malwarepatrol_enabled" == "yes" ] ; then
 		clamav_files
 	fi
 fi
-if [ "$yararulesproject_enabledd" == "yes" ] ; then
+if [ "$|yararulesproject_enabled" == "yes" ] ; then
 	if [ -n "$yararulesproject_dbs" ] ; then
 		for db in $yararulesproject_dbs ; do
 			if echo $db|grep -q "/"; then
@@ -2222,7 +2223,7 @@ fi
 ##############################################################################################################################################
 # Check for updated yararulesproject database files every set number of hours as defined in the "USER CONFIGURATION" section of this script 
 ##############################################################################################################################################
-if [ "$yararulesproject_enabledd" == "yes" ] ; then
+if [ "$|yararulesproject_enabled" == "yes" ] ; then
 	if [ -n "$yararulesproject_dbs" ] ; then
 		if [ `xshok_array_count "$yararulesproject_dbs"` -lt "1" ] ; then
 			xshok_pretty_echo_and_log "Failed yararulesproject_dbs config is invalid or not defined - SKIPPING"

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -1486,6 +1486,7 @@ fi
 # Create $current_dbsfiles containing lists of current and previously active 3rd-party databases
 # so that databases and/or backup files that are no longer being used can be removed.
 current_tmp="$work_dir_work_configs/current-dbs.tmp"
+current_dbs="$work_dir_work_configs/current-dbs.txt"
 
 if [ "$sanesecurity_enabled" == "yes" ] ; then
 	# Create the Sanesecurity rsync "include" file (defines which files to download).
@@ -1543,16 +1544,15 @@ if [ "$additional_enabled" == "yes" ] ; then
 		done
 	fi
 fi
+sort "$current_tmp" > "$current_dbs" 2>/dev/null
+rm -f "$current_tmp"
 
 # Remove 3rd-party databases and/or backup files that are no longer being used.
 if [ "$remove_disabled_databases" == "yes" ] ; then
-	current_dbs="$work_dir_work_configs/current-dbs.txt"
 	previous_dbs="$work_dir_work_configs/previous-dbs.txt"
 	sort "$current_dbs" > "$previous_dbs" 2>/dev/null
 	rm -f "$current_dbs"
 
-	sort "$current_tmp" > "$current_dbs" 2>/dev/null
-	rm -f "$current_tmp"
 	db_changes="$work_dir_work_configs/db-changes.txt"
 	if [ ! -s "$previous_dbs" ] ; then
 		cp -f "$current_dbs" "$previous_dbs" 2>/dev/null


### PR DESCRIPTION
- eXtremeSHOK.com Maintenance
- Added --install-all Install and generate the cron, logroate and man files, autodetects the values $oft based on your config files
- Added functions: xshok_prompt_confirm, xshok_is_file, xshok_is_subdir
- Replaced Y/N prompts with xshok_prompt_confirm
- Bug Fix for disabled databases being removed when the remove_disabled_databases is set to NO (default)
- Added more warnings to remove_script and made it double confirmed
- Remove_script will only remove work_dir if its a sub directory
- Remove_script will only remove files if they are files
- Removed -r switch, --remove-script needs to be used instead of both -r and --remove-script
- Fixed: remove_script not removing logrotate file, cron file, man file