### PR TITLE
Create os conf file for atomic ClamAV repo

### DIFF
--- a/config/os.centos7-atomic.conf
+++ b/config/os.centos7-atomic.conf
@@ -1,0 +1,40 @@
+# This file contains os configuration settings for clamav-unofficial-sigs.sh
+###################
+# This is property of eXtremeSHOK.com
+# You are free to use, modify and distribute, however you may not remove this notice.
+# Copyright (c) Adrian Jon Kriel :: admin@extremeshok.com
+##################
+#
+# Script updates can be found at: https://github.com/extremeshok/clamav-unofficial-sigs
+# 
+# Originially based on: 
+# Script provide by Bill Landry (unofficialsigs@gmail.com).
+#
+# License: BSD (Berkeley Software Distribution)
+#
+##################
+#
+# NOT COMPATIBLE WITH VERSION 3.XX / 4.XX CONFIG 
+#
+################################################################################
+# SEE MASTER.CONF FOR CONFIG EXPLAINATIONS
+################################################################################
+# Rename to os.conf to enable this file
+################################################################################
+
+# RHEL/CentOS 7, using ClamAV packages from EPEL
+
+clam_user="clamav"
+clam_group="clamav"
+
+clam_dbs="/var/clamav"
+
+#clamd_pid="/var/run/clamd.scan/clamd.pid"
+
+clamd_restart_opt="systemctl restart clamd"
+
+clamd_socket="/tmp/clamd.sock"
+
+clamd_reload_opt="clamdscan --config-file=/etc/clamd.d/scan.conf --reload"
+
+# https://eXtremeSHOK.com ######################################################


### PR DESCRIPTION
os config file when using atomic repo which has newer and improved versions of clamav (including missing libclamunrar_iface.so from original EPEL rpms)