### PR TITLE
resolve issue #159 (check_new_version not proxy aware)

### DIFF
--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -1114,9 +1114,9 @@ function check_clamav () {
 # Check for a new version
 function check_new_version () {
   if [ -n "$wget_bin" ] ; then
-    latest_version="$($wget_bin https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/master/clamav-unofficial-sigs.sh -O - 2> /dev/null | $grep_bin "script""_version=" | cut -d '"' -f 2)"
+    latest_version="$($wget_bin $wget_proxy_https $wget_proxy_http https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/master/clamav-unofficial-sigs.sh -O - 2> /dev/null | $grep_bin "script""_version=" | cut -d '"' -f 2)"
   else
-    latest_version="$($curl_bin https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/master/clamav-unofficial-sigs.sh 2> /dev/null | $grep_bin "script""_version=" | cut -d '"' -f 2)"
+    latest_version="$($curl_bin $curl_proxy https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/master/clamav-unofficial-sigs.sh 2> /dev/null | $grep_bin "script""_version=" | cut -d '"' -f 2)"
   fi
   if [ "$latest_version" ] ; then
     if [ ! "$latest_version" == "$script_version" ] ; then

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -1114,9 +1114,9 @@ function check_clamav () {
 # Check for a new version
 function check_new_version () {
   if [ -n "$wget_bin" ] ; then
-    latest_version="$($wget_bin $wget_proxy_https $wget_proxy_http https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/master/clamav-unofficial-sigs.sh -O - 2> /dev/null | $grep_bin "script""_version=" | cut -d '"' -f 2)"
+    latest_version="$($wget_bin "$wget_proxy_https" "$wget_proxy_http" https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/master/clamav-unofficial-sigs.sh -O - 2> /dev/null | $grep_bin "script""_version=" | cut -d '"' -f 2)"
   else
-    latest_version="$($curl_bin $curl_proxy https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/master/clamav-unofficial-sigs.sh 2> /dev/null | $grep_bin "script""_version=" | cut -d '"' -f 2)"
+    latest_version="$($curl_bin "$curl_proxy" https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/master/clamav-unofficial-sigs.sh 2> /dev/null | $grep_bin "script""_version=" | cut -d '"' -f 2)"
   fi
   if [ "$latest_version" ] ; then
     if [ ! "$latest_version" == "$script_version" ] ; then

--- a/config/master.conf
+++ b/config/master.conf
@@ -457,8 +457,8 @@ selinux_fixes="no" # Default is "no" ignore ssl errors and warnings
 # format of "hostname:port".  For wget, also note the https and http
 #rsync_proxy=""
 #curl_proxy=""
-#wget_proxy_http="http://username:password@proxy_host:proxy_port"
-#wget_proxy_https="https://username:password@proxy_host:proxy_port"
+#wget_proxy_http="-e http_proxy=http://username:password@proxy_host:proxy_port"
+#wget_proxy_https="-e https_proxy=https://username:password@proxy_host:proxy_port"
 
 
 # Custom Cron install settings, these are detected and only used if you want to override


### PR DESCRIPTION
added proxy variables to the correct binary (wget or curl)
also include "-e http_proxy=" and "-e https_proxy=" to the respective variables so wget actually knows how to handle the proxy.
