### PR TITLE
Adding log_pipe_cmd to allow logging to command instead of file

### DIFF
--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -240,17 +240,21 @@ function xshok_pretty_echo_and_log () { # "string" "repeating" "count" "type"
 
   # Handle logging
   if [ "$enable_log" == "yes" ] ; then
-    if [ ! -e "$log_file_path/$log_file_name" ] ; then
-      # xshok_mkdir_ownership "$log_file_path"
-      mkdir -p "$log_file_path"
-      touch "$log_file_path/$log_file_name" 2>/dev/null
-      perms chown -f "$clam_user:$clam_group" "$log_file_path/$log_file_name"
-    fi
-    if [ ! -w "$log_file_path/$log_file_name" ] ; then
-      echo "Warning: Logging Disabled, as file not writable: $log_file_path/$log_file_name"
-      enable_log="no"
+    if [ ! -z "$log_pipe_cmd" ] ; then
+      echo "$1" | "$log_pipe_cmd"
     else
-      echo "$(date "+%b %d %T")" "$1" >> "$log_file_path/$log_file_name"
+      if [ ! -e "$log_file_path/$log_file_name" ] ; then
+        # xshok_mkdir_ownership "$log_file_path"
+        mkdir -p "$log_file_path"
+        touch "$log_file_path/$log_file_name" 2>/dev/null
+        perms chown -f "$clam_user:$clam_group" "$log_file_path/$log_file_name"
+      fi
+      if [ ! -w "$log_file_path/$log_file_name" ] ; then
+        echo "Warning: Logging Disabled, as file not writable: $log_file_path/$log_file_name"
+        enable_log="no"
+      else
+        echo "$(date "+%b %d %T")" "$1" >> "$log_file_path/$log_file_name"
+      fi
     fi
   fi
 }

--- a/config/master.conf
+++ b/config/master.conf
@@ -66,6 +66,8 @@ work_dir="/var/lib/clamav-unofficial-sigs"   #Top level working directory
 logging_enabled="yes"
 log_file_path="/var/log/clamav-unofficial-sigs"
 log_file_name="clamav-unofficial-sigs.log"
+## Use a program to log messages
+#log_pipe_cmd="/usr/bin/logger -it 'clamav-unofficial-sigs'"
 
 
 # =========================


### PR DESCRIPTION
Added log_pipe_cmd to configuration options to let users pipe through an external program or script.

(eg using logger for syslog or a separate script inside a docker container for STDOUT/STDERR on the main process)