### PR TITLE
Modify clamav paths that have been changed in ZCS 8.7+.

### DIFF
--- a/config/os.zimbra.conf
+++ b/config/os.zimbra.conf
@@ -31,8 +31,8 @@ work_dir="/opt/zimbra/data/clamav-unofficial-sigs"
 
 log_file_path="/opt/zimbra/log"
 
-clamd_reload_opt="/opt/zimbra/clamav/bin/clamdscan --config-file=/opt/zimbra/conf/clamd.conf --reload"
+clamd_reload_opt="/opt/zimbra/common/bin/clamdscan --config-file=/opt/zimbra/conf/clamd.conf --reload"
 
-clamscan_bin="/opt/zimbra/clamav/bin/clamscan"
+clamscan_bin="/opt/zimbra/common/bin/clamscan"
 
 # https://eXtremeSHOK.com ######################################################


### PR DESCRIPTION
ZCS 8.7+ underwent some repackaging work, which has changed the paths for the clamav binaries. This change accounts for those.