### PR TITLE
Use `/sbin/service` rather `service` and `reload` rather `restart` for RHEL/CentOS 6

### DIFF
--- a/config/os.centos6-cpanel.conf
+++ b/config/os.centos6-cpanel.conf
@@ -27,7 +27,7 @@ clam_dbs="/usr/local/cpanel/3rdparty/share/clamav"
 
 clamd_pid="/var/run/clamav/clamd.pid"
 
-clamd_restart_opt="service clamd restart"
+clamd_restart_opt="/sbin/service clamd reload"
 
 #clamd_socket="/var/run/clamd.socket"
 

--- a/config/os.centos6.conf
+++ b/config/os.centos6.conf
@@ -27,7 +27,7 @@ clam_dbs="/var/lib/clamav"
 
 clamd_pid="/var/run/clamav/clamd.pid"
 
-clamd_restart_opt="service clamd restart"
+clamd_restart_opt="/sbin/service clamd reload"
 
 #clamd_socket="/var/run/clamd.socket"
 


### PR DESCRIPTION
By default RHEL/CentOS 6 doesn't have `/sbin` in `$PATH`, thus `service clamd restart` poorly fails by default. Aside of that, a `reload` rather a `restart` is sufficient for ClamAV as well to reload the ClamAV databases (worked already for years now). If at all this should be turned into `condrestart` rather `restart`, because RHEL/CentOS 6 might not use `/etc/init.d/clamd` service at all, but `/etc/init.d/clamd.amavisd` service; which gets relevant when ClamAV is used only for Amavisd-New, but not for the actual system...nobody would like to see a maybe unused service to be started by a cronjob...