### PR TITLE
6.1.1

### DIFF
--- a/.t/ci-test.sh
+++ b/.t/ci-test.sh
@@ -14,8 +14,8 @@ if [ -e "/var/lib/clamav/sanesecurity.ftm" ] ; then
 	rm -f /var/lib/clamav/sanesecurity.ftm
 fi
 
-echo "running script as root"
-sudo bash /usr/sbin/clamav-unofficial-sigs
+echo "running script as root and verbose"
+sudo bash /usr/sbin/clamav-unofficial-sigs --verbose
 if [ "$?" -eq "0" ] ; then
 	echo .. OK
 else
@@ -23,8 +23,8 @@ else
   exit 1
 fi
 
-echo "running script as clamav"
-sudo -u clamav  [ -x /usr/sbin/clamav-unofficial-sigs ] && bash /usr/sbin/clamav-unofficial-sigs --force
+echo "running script as clamav and silence"
+sudo -u clamav  [ -x /usr/sbin/clamav-unofficial-sigs ] && bash /usr/sbin/clamav-unofficial-sigs --force --silence
 if [ "$?" -eq "0" ] ; then
 	echo .. OK
 else

--- a/.t/ci-test.sh
+++ b/.t/ci-test.sh
@@ -14,7 +14,18 @@ if [ -e "/var/lib/clamav/sanesecurity.ftm" ] ; then
 	rm -f /var/lib/clamav/sanesecurity.ftm
 fi
 
+echo "running script as root and verbose and force_wget"
+sudo cp -f .t/tests/user_wget.conf /etc/clamav-unofficial-sigs/user.conf
+sudo bash /usr/sbin/clamav-unofficial-sigs --verbose
+if [ "$?" -eq "0" ] ; then
+	echo .. OK
+else
+ 	echo .. ERROR
+  exit 1
+fi
+
 echo "running script as root and verbose"
+sudo cp -f .t/tests/user.conf /etc/clamav-unofficial-sigs/user.conf
 sudo bash /usr/sbin/clamav-unofficial-sigs --verbose
 if [ "$?" -eq "0" ] ; then
 	echo .. OK

--- a/.t/tests/user_wget.conf
+++ b/.t/tests/user_wget.conf
@@ -1,0 +1,59 @@
+###################
+# This is property of eXtremeSHOK.com
+# You are free to use, modify and distribute, however you may not remove this notice.
+# Copyright (c) Adrian Jon Kriel :: admin@extremeshok.com
+# License: BSD (Berkeley Software Distribution)
+##################
+
+malwarepatrol_enabled="yes"
+malwarepatrol_receipt_code=$ci_malwarepatrol_receipt_code
+malwarepatrol_product_code=$ci_malwarepatrol_receipt_code
+malwarepatrol_list=$ci_malwarepatrol_receipt_code
+malwarepatrol_free=$ci_malwarepatrol_free
+
+securiteinfo_enabled="yes"
+securiteinfo_authorisation_signature=$ci_securiteinfo_authorisation_signature
+
+sanesecurity_enabled="yes"
+
+linuxmalwaredetect_enabled="yes"
+
+# THIS NEEDS TO BE TESTED
+yararules_enabled="no"
+enable_yararules="no"
+
+# Default dbs rating
+# valid rating: LOW, MEDIUM, HIGH
+default_dbs_rating="MEDIUM"
+
+# Per Database
+# These ratings will override the global rating for the specific database
+# valid rating: LOW, MEDIUM, HIGH, DISABLE
+sanesecurity_dbs_rating="HIGH"
+#securiteinfo_dbs_rating=""
+#linuxmalwaredetect_dbs_rating=""
+#yararulesproject_dbs_rating=""
+
+enable_gpg="no"
+
+user_configuration_complete="yes"
+
+declare -a additional_dbs=(
+https://raw.githubusercontent.com/wmetcalf/clam-punch/master/miscreantpunch099.ldb
+https://raw.githubusercontent.com/wmetcalf/clam-punch/master/MiscreantPunch099-Low.ldb
+) #END ADDITIONAL DATABASES
+
+
+declare -a securiteinfo_dbs=(
+securiteinfo.ign2|REQUIRED
+securiteinfo.hdb|LOW
+javascript.ndb|LOW
+securiteinfohtml.hdb|LOW
+securiteinfoascii.hdb|LOW
+securiteinfopdf.hdb|LOW
+securiteinfoandroid.hdb|LOW #
+spam_marketing.ndb|HIGH
+) #END SECURITEINFO DATABASES
+
+#foce wget
+force_wget="yes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
 install:
   - sudo mkdir -p /etc/clamav-unofficial-sigs
   - sudo cp -f config/master.conf /etc/clamav-unofficial-sigs/master.conf
-  - sudo cp -f config/os.ubuntu.conf /etc/clamav-unofficial-sigs/os.conf
+  - sudo cp -f config/os/os.ubuntu.conf /etc/clamav-unofficial-sigs/os.conf
   - sudo cp -f clamav-unofficial-sigs.sh /usr/sbin/clamav-unofficial-sigs
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ dist: bionic
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y ca-certificates wget rsync p7zip-full shellcheck -qq
+  - sudo apt-get install -y ca-certificates curl wget rsync p7zip-full shellcheck -qq
   #- sudo pip install bashate
   # - "sudo mkdir -p tmp/cache/"
   # - "ls -laFh tmp/cache/clamav-dbs"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,8 +8,8 @@ Script updates can be found at: https://github.com/extremeshok/clamav-unofficial
 
 # Operating System Specific Install Guides
 * CentOS : https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/guides/centos7.md
-* Ubuntu : https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/guides/ununtu-debian.md
-* Debian : https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/guides/ununtu-debian.md
+* Ubuntu : https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/guides/ubuntu-debian.md
+* Debian : https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/guides/ubuntu-debian.md
 * Mac OSX : https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/guides/macosx.md
 * pFsense : https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/guides/pfsense.md
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Usage: clamav-unofficial-sigs.sh 	 [OPTION] [PATH|FILE]
   based on your config files
 
 
+
 --install-logrotate 	 Install and generate the logrotate file, autodetects the
   values based on your config files
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Usage: clamav-unofficial-sigs.sh 	 [OPTION] [PATH|FILE]
  - Fix: suppress all non-error output under cron/non interactive terminal
  - Fix: check log file is not a link before setting permissions, only set if owned by root.
  - Fix: failed to create symbolic link
+ - Fix: curl --compress ->> cirl --compressed
  - Minor enhancement to travis-ci checks
  - Incremented the config to version 77
 

--- a/README.md
+++ b/README.md
@@ -185,8 +185,11 @@ Usage: clamav-unofficial-sigs.sh 	 [OPTION] [PATH|FILE]
  - Update os.archlinux.conf, thanks @amishmm
  - master.conf set default dbs rating to medium
  - user.conf better suggested values
+ - Default to using curl, less logic required (lower cpu)
+ - force_curl replaces force_wget
  - Fix: suppress all non-error output under cron/non interactive terminal
  - Fix: check log file is not a link before setting permissions, only set if owned by root.
+ - Fix: failed to create symbolic link
  - Minor enhancement to travis-ci checks
  - Incremented the config to version 77
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Usage: clamav-unofficial-sigs.sh 	 [OPTION] [PATH|FILE]
  - master.conf set default dbs rating to medium
  - user.conf better suggested values
  - Default to using curl, less logic required (lower cpu)
- - force_curl replaces force_wget
+ - force_curl replaced with force_wget
  - Fix: suppress all non-error output under cron/non interactive terminal
  - Fix: check log file is not a link before setting permissions, only set if owned by root.
  - Fix: failed to create symbolic link

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Usage: clamav-unofficial-sigs.sh 	 [OPTION] [PATH|FILE]
  - Fix: suppress all non-error output under cron/non interactive terminal
  - Fix: check log file is not a link before setting permissions, only set if owned by root.
  - Fix: failed to create symbolic link
- - Fix: curl --compress ->> cirl --compressed
+ - Fix: curl --compress ->> curl --compressed
  - Minor enhancement to travis-ci checks
  - Incremented the config to version 77
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ Usage: clamav-unofficial-sigs.sh 	 [OPTION] [PATH|FILE]
   based on your config files
 
 
-
 --install-logrotate 	 Install and generate the logrotate file, autodetects the
   values based on your config files
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Github fork of the sourceforge hosted and non maintained utility.
 ## Description
 The clamav-unofficial-sigs script provides a simple way to download, test, and update third-party signature databases provided by Sanesecurity, FOXHOLE, OITC, Scamnailer, BOFHLAND, CRDF, Porcupine, Securiteinfo, MalwarePatrol, Yara-Rules Project, etc. The script will also generate and install cron, logrotate, and man files.
 
-#### Checkout some of our other solutions: https://github.com/extremeshok?tab=repositories
+## Checkout some of our other solutions: https://github.com/extremeshok?tab=repositories
 
 ### Support / Suggestions / Comments
 Please post them on the issue tracker : https://github.com/extremeshok/clamav-unofficial-sigs/issues
@@ -28,8 +28,8 @@ https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/INSTALL.md
 
 ### Operating System Specific Install Guides
 * CentOS : https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/guides/centos7.md
-* Ubuntu : https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/guides/ununtu-debian.md
-* Debian : https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/guides/ununtu-debian.md
+* Ubuntu : https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/guides/ubuntu-debian.md
+* Debian : https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/guides/ubuntu-debian.md
 * Mac OSX : https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/guides/macosx.md
 * pFsense : https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/guides/pfsense.md
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,16 @@ Usage: clamav-unofficial-sigs.sh 	 [OPTION] [PATH|FILE]
   its associated files and databases from the system
 
 ## Change Log
+### Version 6.1.1 (Updated 02 September 2019)
+ - eXtremeSHOK.com Maintenance
+ - Update os.archlinux.conf, thanks @amishmm
+ - master.conf set default dbs rating to medium
+ - user.conf better suggested values
+ - Fix: suppress all non-error output under cron/non interactive terminal
+ - Fix: check log file is not a link before setting permissions, only set if owned by root.
+ - Minor enhancement to travis-ci checks
+ - Incremented the config to version 77
+
 ### Version 6.1.0 (Updated 27 August 2019)
  - eXtremeSHOK.com Maintenance
  - Thanks Reio Remma & Oliver Nissen

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -1490,7 +1490,7 @@ fi
 if [ ! -z "$wget_bin" ] ; then
   # wget compression support
   if $wget_bin --help | $grep_bin -q "compression=TYPE" ; then
-    wget_compression="--compressedion=auto"
+    wget_compression="--compression=auto"
   else
     wget_compression=""
   fi

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -3326,9 +3326,15 @@ check_new_config_version
 xshok_cleanup
 
 # Set the permission of the log file, to fix any permission errors, this is done to fix cron errors after running the script as root.
-if [ "$enable_log" == "yes" ] ; then
-	if [ -w "${log_file_path}/${log_file_name}" ] ; then
-		perms chown -f "${clam_user}:${clam_group}" "${log_file_path}/${log_file_name}"
+if xshok_is_root ; then
+	if [ "$enable_log" == "yes" ] ; then
+		# check if the file is owned by root (the current user)
+		if [ -O "${log_file_path}/${log_file_name}" ] ; then
+			# checks the file is writable and a file (not a symlink/link)
+			if [ -w "${log_file_path}/${log_file_name}" ] && [ -F "${log_file_path}/${log_file_name}" ] ; then
+				perms chown -f "${clam_user}:${clam_group}" "${log_file_path}/${log_file_name}"
+			fi
+		fi
 	fi
 fi
 

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 # shellcheck disable=SC2119
 # shellcheck disable=SC2120

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -223,7 +223,7 @@ function xshok_pretty_echo_and_log() { # "string" "repeating" "count" "type"
 	myrepeating="$2"
 	mycount="$3"
 	mytype="$4"
-	if [ "$comment_silence" != "yes" ] ; then
+	if [ "$comment_silence" != "yes" ] && [ "$force_verbose" != "yes" ]; then
 		if [ ! -t 1 ] ; then
 			comment_silence="yes"
 		fi
@@ -1429,6 +1429,7 @@ fi
 config_version="0"
 do_clamd_reload="0"
 comment_silence="no"
+force_verbose="no"
 logging_enabled="no"
 force_updates="no"
 enable_log="no"
@@ -1894,7 +1895,7 @@ fi
 
 # Silence wget output and only report errors - useful if script is run via cron.
 if [ "$downloader_silence" == "yes" ] ; then
-  wget_output_level="--no-verbose" #--quiet
+  wget_output_level="--quiet"
   curl_output_level="--silent --show-error"
 else
   wget_output_level="--no-verbose"

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -325,7 +325,7 @@ function xshok_file_download() { #outputfile #url #notimestamp
   if [ "${1}" ] && [ "${2}" ] ; then
 		if [ -n "$curl_bin" ] ; then
 			# shellcheck disable=SC2086
-			$curl_bin --fail --compress $curl_proxy $curl_insecure $curl_output_level --connect-timeout "${downloader_connect_timeout}" --remote-time --location --retry "${downloader_tries}" --max-time "${downloader_max_time}" --time-cond "${1}" --output "${1}" "${2}"
+			$curl_bin --fail --compressed $curl_proxy $curl_insecure $curl_output_level --connect-timeout "${downloader_connect_timeout}" --remote-time --location --retry "${downloader_tries}" --max-time "${downloader_max_time}" --time-cond "${1}" --output "${1}" "${2}"
 			result=$?
 		else
 			if [ ! "${3}" ] ; then
@@ -1276,7 +1276,7 @@ function check_clamav() {
 function check_new_version() {
   if [ -n "$curl_bin" ] ; then
 		# shellcheck disable=SC2086
-		latest_version="$($curl_bin --compress $curl_proxy $curl_insecure $curl_output_level --connect-timeout "${downloader_connect_timeout}" --remote-time --location --retry "${downloader_tries}" --max-time "${downloader_max_time}" "https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/${git_branch}/clamav-unofficial-sigs.sh" 2> /dev/null | $grep_bin "^script_version=" | head -n1 | cut -d '"' -f 2)"
+		latest_version="$($curl_bin --compressed $curl_proxy $curl_insecure $curl_output_level --connect-timeout "${downloader_connect_timeout}" --remote-time --location --retry "${downloader_tries}" --max-time "${downloader_max_time}" "https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/${git_branch}/clamav-unofficial-sigs.sh" 2> /dev/null | $grep_bin "^script_version=" | head -n1 | cut -d '"' -f 2)"
 	else
 		# shellcheck disable=SC2086
 		latest_version="$($wget_bin $wget_compression $wget_proxy $wget_insecure $wget_output_level --connect-timeout="${downloader_connect_timeout}" --random-wait --tries="${downloader_tries}" --timeout="${downloader_max_time}" "https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/${git_branch}/clamav-unofficial-sigs.sh" -O - 2> /dev/null | $grep_bin "^script_version=" | head -n1 | cut -d '"' -f 2)"
@@ -1293,7 +1293,7 @@ function check_new_version() {
 function check_new_config_version() {
   if [ -n "$curl_bin" ] ; then
 		# shellcheck disable=SC2086
-		latest_config_version="$($curl_bin --compress $curl_proxy $curl_insecure $curl_output_level --connect-timeout "${downloader_connect_timeout}" --remote-time --location --retry "${downloader_tries}" --max-time "${downloader_max_time}" "https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/${git_branch}/config/master.conf" 2> /dev/null | $grep_bin "^config_version=" | head -n1 | cut -d '"' -f 2)"
+		latest_config_version="$($curl_bin --compressed $curl_proxy $curl_insecure $curl_output_level --connect-timeout "${downloader_connect_timeout}" --remote-time --location --retry "${downloader_tries}" --max-time "${downloader_max_time}" "https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/${git_branch}/config/master.conf" 2> /dev/null | $grep_bin "^config_version=" | head -n1 | cut -d '"' -f 2)"
   else
 		# shellcheck disable=SC2086
 		latest_config_version="$($wget_bin $wget_compression $wget_proxy $wget_insecure $wget_output_level --connect-timeout="${downloader_connect_timeout}" --random-wait --tries="${downloader_tries}" --timeout="${downloader_max_time}" "https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/${git_branch}/config/master.conf" -O - 2> /dev/null | $grep_bin "^config_version=" | head -n1 | cut -d '"' -f 2)"
@@ -1490,7 +1490,7 @@ fi
 if [ ! -z "$wget_bin" ] ; then
   # wget compression support
   if $wget_bin --help | $grep_bin -q "compression=TYPE" ; then
-    wget_compression="--compression=auto"
+    wget_compression="--compressedion=auto"
   else
     wget_compression=""
   fi

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env bash
 # shellcheck disable=SC2119
 # shellcheck disable=SC2120

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -324,9 +324,15 @@ function xshok_draw_time_remaining() { #time_remaining #update_hours #name
 function xshok_file_download() { #outputfile #url #notimestamp
   if [ "${1}" ] && [ "${2}" ] ; then
 		if [ -n "$curl_bin" ] ; then
-			# shellcheck disable=SC2086
-			$curl_bin --fail --compressed $curl_proxy $curl_insecure $curl_output_level --connect-timeout "${downloader_connect_timeout}" --remote-time --location --retry "${downloader_tries}" --max-time "${downloader_max_time}" --time-cond "${1}" --output "${1}" "${2}"
-			result=$?
+			if [ -f "${1}" ] ; then
+				# shellcheck disable=SC2086
+				$curl_bin --fail --compressed $curl_proxy $curl_insecure $curl_output_level --connect-timeout "${downloader_connect_timeout}" --remote-time --location --retry "${downloader_tries}" --max-time "${downloader_max_time}" --time-cond "${1}" --output "${1}" "${2}"
+				result=$?
+			else
+				# shellcheck disable=SC2086
+				$curl_bin --fail --compressed $curl_proxy $curl_insecure $curl_output_level --connect-timeout "${downloader_connect_timeout}" --remote-time --location --retry "${downloader_tries}" --max-time "${downloader_max_time}" --output "${1}" "${2}"
+				result=$?
+			fi
 		else
 			if [ ! "${3}" ] ; then
 				# the following is required because wget, cannot do --timestamping and --output-document together

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -3332,7 +3332,7 @@ if xshok_is_root ; then
 		# check if the file is owned by root (the current user)
 		if [ -O "${log_file_path}/${log_file_name}" ] ; then
 			# checks the file is writable and a file (not a symlink/link)
-			if [ -w "${log_file_path}/${log_file_name}" ] && [ -F "${log_file_path}/${log_file_name}" ] ; then
+			if [ -w "${log_file_path}/${log_file_name}" ] && [ -f "${log_file_path}/${log_file_name}" ] ; then
 				perms chown -f "${clam_user}:${clam_group}" "${log_file_path}/${log_file_name}"
 			fi
 		fi

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -1465,18 +1465,11 @@ fi
 if [ -z "$curl_bin" ]; then
 	curl_bin="$(command -v curl 2> /dev/null)"
 fi
-# Force wget over curl.
-if [ ! -z "$curl_bin" ] && [ "$force_wget" == "yes" ] ; then
-		xshok_pretty_echo_and_log "NOTICE: Force wget enabled"
-	  curl_bin=""
-fi
 # Detect support for wget
-if [ -z "$curl_bin" ]; then
-	if [ -x /usr/sfw/bin/wget ] ; then
-	  wget_bin="/usr/sfw/bin/wget"
-	else
-	  wget_bin="$(command -v wget 2> /dev/null)"
-	fi
+if [ -x /usr/sfw/bin/wget ] ; then
+  wget_bin="/usr/sfw/bin/wget"
+else
+  wget_bin="$(command -v wget 2> /dev/null)"
 fi
 if [ -z "$wget_bin" ] && [ -z "$curl_bin" ]; then
   curl_bin="$(command -v curl 2> /dev/null)"
@@ -1821,7 +1814,7 @@ if [ "$enable_gpg" == "yes" ] ; then
   fi
 fi
 if [ "$enable_gpg" != "yes" ] ; then
-  xshok_pretty_echo_and_log "GnuPG / signature verification disabled"
+  xshok_pretty_echo_and_log "NOTICE: GnuPG / signature verification disabled"
 fi
 # Check default directories are defined
 if [ -z "$work_dir" ] ; then
@@ -1846,13 +1839,19 @@ fi
 
 # Reset the update timers to force a full update.
 if [ "$force_updates" == "yes" ] ; then
-  xshok_pretty_echo_and_log "Force Updates: enabled"
+  xshok_pretty_echo_and_log "NOTICE: Forced updates enabled"
   sanesecurity_update_hours="0"
   securiteinfo_update_hours="0"
   linuxmalwaredetect_update_hours="0"
   malwarepatrol_update_hours="0"
   yararulesproject_update_hours="0"
   additional_update_hours="0"
+fi
+
+# Force wget over curl.
+if [ ! -z "$wget" ] && [ "$force_wget" == "yes" ] ; then
+		xshok_pretty_echo_and_log "NOTICE: Force wget enabled"
+	  curl_bin=""
 fi
 
 # Enable pid file to prevent issues with multiple instances

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -1435,6 +1435,7 @@ comment_silence="no"
 force_verbose="no"
 logging_enabled="no"
 force_updates="no"
+force_wget="no"
 enable_log="no"
 custom_config="no"
 we_have_a_config="0"
@@ -1464,6 +1465,11 @@ fi
 if [ -z "$curl_bin" ]; then
 	curl_bin="$(command -v curl 2> /dev/null)"
 fi
+# Force wget over curl.
+if [ ! -z "$curl_bin" ] && [ "$force_wget" == "yes" ] ; then
+		xshok_pretty_echo_and_log "NOTICE: Force wget enabled"
+	  curl_bin=""
+fi
 # Detect support for wget
 if [ -z "$curl_bin" ]; then
 	if [ -x /usr/sfw/bin/wget ] ; then
@@ -1472,13 +1478,6 @@ if [ -z "$curl_bin" ]; then
 	  wget_bin="$(command -v wget 2> /dev/null)"
 	fi
 fi
-
-# Force wget over curl.
-if [ ! -z "$curl_bin" ] && [ "$force_wget" == "yes" ] ; then
-		xshok_pretty_echo_and_log "NOTICE: Force wget enabled"
-	  curl_bin=""
-fi
-
 if [ -z "$wget_bin" ] && [ -z "$curl_bin" ]; then
   curl_bin="$(command -v curl 2> /dev/null)"
   if [ -z "$curl_bin" ] ; then

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -1387,8 +1387,8 @@ EOF
 ################################################################################
 
 # Script Info
-script_version="6.1.0"
-script_version_date="2019-08-27"
+script_version="6.1.1"
+script_version_date="2019-09-02"
 minimum_required_config_version="76"
 minimum_yara_clamav_version="0.99"
 

--- a/config/master.conf
+++ b/config/master.conf
@@ -1,4 +1,3 @@
-
 # This file contains master configuration settings for clamav-unofficial-sigs.sh
 ###################
 # This is property of eXtremeSHOK.com

--- a/config/master.conf
+++ b/config/master.conf
@@ -1,3 +1,4 @@
+
 # This file contains master configuration settings for clamav-unofficial-sigs.sh
 ###################
 # This is property of eXtremeSHOK.com

--- a/config/master.conf
+++ b/config/master.conf
@@ -548,6 +548,6 @@ yararulesproject_url="https://raw.githubusercontent.com/Yara-Rules/rules/master"
 
 # ========================
 # DO NOT EDIT !
-config_version="76"
+config_version="77"
 
 # https://eXtremeSHOK.com ######################################################

--- a/config/master.conf
+++ b/config/master.conf
@@ -414,8 +414,8 @@ max_sleep_time="600"   # Default maximum is 600 seconds (10 minutes).
 #curl_bin="/usr/bin/curl"
 #gpg_bin="/usr/bin/gpg"
 
-# force curl, by default wget is used when curl and wget is present.
-force_curl="no"
+# force wget, by default curl is used when curl and wget is present.
+force_wget="no"
 
 # GnuPG / Signature verification
 # To disable usage of gpg, set the following variable to "no".

--- a/config/user.conf
+++ b/config/user.conf
@@ -1,3 +1,4 @@
+
 # This file contains user configuration settings for clamav-unofficial-sigs.sh
 ###################
 # This is property of eXtremeSHOK.com

--- a/config/user.conf
+++ b/config/user.conf
@@ -28,17 +28,17 @@
 
 #securiteinfo_authorisation_signature="YOUR-SIGNATURE-NUMBER"
 
-# Default dbs rating
+# Default dbs rating (Default: MEDIUM)
 # valid rating: LOW, MEDIUM, HIGH
 #default_dbs_rating="HIGH"
 
 # Per Database
 # These ratings will override the global rating for the specific database
 # valid rating: LOW, MEDIUM, HIGH, DISABLE
-#sanesecurity_dbs_rating=""
-#securiteinfo_dbs_rating=""
-#linuxmalwaredetect_dbs_rating=""
-#yararulesproject_dbs_rating=""
+#sanesecurity_dbs_rating="HIGH"
+#securiteinfo_dbs_rating="HIGH"
+#linuxmalwaredetect_dbs_rating="HIGH"
+#yararulesproject_dbs_rating="HIGH"
 
 # =========================
 # Additional signature databases

--- a/config/user.conf
+++ b/config/user.conf
@@ -1,4 +1,3 @@
-
 # This file contains user configuration settings for clamav-unofficial-sigs.sh
 ###################
 # This is property of eXtremeSHOK.com

--- a/guides/ubuntu-debian.md
+++ b/guides/ubuntu-debian.md
@@ -21,9 +21,9 @@ wget https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/master
 wget https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/master/config/user.conf -c -O /etc/clamav-unofficial-sigs/user.conf
 ```
 Select your operating system config from https://github.com/extremeshok/clamav-unofficial-sigs/tree/master/config/
-**replace os.centos7.conf with your required config, centos6 = os.centos6.conf, centos7-atomic = os.centos7-atomic.conf, centos6-cpanel = os.centos6-cpanel.conf**
+**replace os.debian9.conf with your required config, ubuntu = ubuntu.conf, debian9 = os.debian9.conf, debian8 = os.debian8.conf, debian8-systemd = os.debian8.systemd.conf, debian7 = os.debian7.conf**
 ```
-os_conf="os.centos7.conf"
+os_conf="os.debian9.conf"
 wget "https://raw.githubusercontent.com/extremeshok/clamav-unofficial-sigs/master/config/os/${os_conf}" -c -O /etc/clamav-unofficial-sigs/os.conf
 ```
 


### PR DESCRIPTION
 - eXtremeSHOK.com Maintenance
 - Update os.archlinux.conf, thanks @amishmm
 - master.conf set default dbs rating to medium
 - user.conf better suggested values
 - Default to using curl, less logic required (lower cpu)
 - force_curl replaces force_wget
 - Fix: suppress all non-error output under cron/non interactive terminal
 - Fix: check log file is not a link before setting permissions, only set if owned by root.
 - Fix: failed to create symbolic link
 - Fix: curl --compress ->> cirl --compressed
 - Minor enhancement to travis-ci checks
 - Incremented the config to version 77