### PR TITLE
Add support for config_dir path on newer versions of Zimbra

### DIFF
--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -1431,6 +1431,8 @@ elif [ -f "/usr/local/etc/clamav-unofficial-sigs/master.conf" ] ; then
   config_dir="/usr/local/etc/clamav-unofficial-sigs/"
 elif [ -f "/opt/zimbra/config/clamav-unofficial-sigs/master.conf" ] ; then
   config_dir="/opt/zimbra/config/clamav-unofficial-sigs/"
+elif [ -f "/opt/zimbra/conf/clamav-unofficial-sigs/master.conf" ] ; then
+  config_dir="/opt/zimbra/conf/clamav-unofficial-sigs/"
 else
   xshok_pretty_echo_and_log "ERROR: config_dir (/etc/clamav-unofficial-sigs/master.conf) could not be found"
   exit 1


### PR DESCRIPTION
Newer versions of Zimbra use `/opt/zimbra/conf/` path for config files.