### PR TITLE
Fix the bug in xshok_file_download()

### DIFF
--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -362,13 +362,13 @@ function xshok_file_download() { #outputfile #url #notimestamp
 						rm -f "$wget_output_link"
 					fi
 				fi
+				cd "$this_dir" || exit
 			else
 				# shellcheck disable=SC2086
 				$wget_bin $wget_compression $wget_proxy $wget_insecure $wget_output_level --connect-timeout="${downloader_connect_timeout}" --random-wait --tries="${downloader_tries}" --timeout="${downloader_max_time}" --output-document="${1}" "${2}"
 				result=$?
 			fi
     fi
-		cd "$this_dir" || exit
     return $result
   fi
 }


### PR DESCRIPTION
$this_dir variable is defined only inside 'if [ ! "${3}" ]' block. Using it outside this block leads to 'cd: : Permission denied' error.

Solution: move 'cd "$this_dir" || exit' line inside this "if" block - you need to cd back to $this_dir only at the end of this block to return from $output_dir.