### PR TITLE
Fixed URLhaus log message.

### DIFF
--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -3098,7 +3098,7 @@ if [ "$urlhaus_enabled" == "yes" ] ; then
       if [ "$time_interval" -ge "$((update_interval - 600))" ] ; then
         echo "$current_time" > "${work_dir_work_configs}/last-urlhaus-update.txt"
 
-        xshok_pretty_echo_and_log "Yara-Rules Database File Updates" "="
+        xshok_pretty_echo_and_log "URLhaus Database File Updates" "="
         xshok_pretty_echo_and_log "Checking for urlhaus updates..."
         urlhaus_updates="0"
         for db_file in "${urlhaus_dbs[@]}" ; do
@@ -3185,7 +3185,7 @@ if [ "$urlhaus_enabled" == "yes" ] ; then
         fi
       else
 
-        xshok_pretty_echo_and_log "Yara-Rules Database File Updates" "="
+        xshok_pretty_echo_and_log "URLhaus Database File Updates" "="
         xshok_draw_time_remaining "$((update_interval - time_interval))" "$urlhaus_update_hours" "urlhaus"
       fi
     fi


### PR DESCRIPTION
The code in clamav-unofficial-sigs.sh for URLhaus seems to be mostly copied from Yara-Rules with name changes as required, except the "Yara-Rules Database File Updates" message was missed in two places.