### PR TITLE
config/os/os.gentoo.conf: disable updates and upgrade checks.

### DIFF
--- a/config/os/os.gentoo.conf
+++ b/config/os/os.gentoo.conf
@@ -31,4 +31,7 @@ clamd_restart_opt="clamdscan --reload"
 
 clamd_socket="/var/run/clamav/clamd.sock"
 
+allow_upgrades="no"
+allow_update_checks="no"
+
 # https://eXtremeSHOK.com ######################################################


### PR DESCRIPTION
On Gentoo, these functions are handled by the package manager,
and wouldn't work if you tried them besides. So let's just
turn them off to improve the error message in that case.