### PR TITLE
master.conf: Enable yararulesproject by default

### DIFF
--- a/config/master.conf
+++ b/config/master.conf
@@ -124,7 +124,7 @@ malwarepatrol_enabled="yes"   # Malware Patrol
 sanesecurity_enabled="yes"   # Sanesecurity
 securiteinfo_enabled="yes"   # SecuriteInfo
 urlhaus_enabled="yes"   # urlhaus
-yararulesproject_enabled="no"   # Yara-Rule Project, automatically disabled if clamav is older than 0.100 and enable_yararules is disabled
+yararulesproject_enabled="yes"   # Yara-Rule Project, automatically disabled if clamav is older than 0.100 and enable_yararules is disabled
 
 # Disabled by default
 ## Enabling this will also cause the yararulesproject to be enabled if they are det to enabled.


### PR DESCRIPTION
According to the README, the yara rules project should be enabled by default.