### PR TITLE
master.conf: Ignore yara files that include modules

### DIFF
--- a/config/master.conf
+++ b/config/master.conf
@@ -397,9 +397,6 @@ email/email_Ukraine_BE_powerattack.yar|MEDIUM
 email/scam.yar|MEDIUM
 # Detect well-known software packers, that can be used by malware to hide itself.
 packers/JJencode.yar|MEDIUM
-packers/packer_compiler_signatures.yar|MEDIUM
-packers/packer.yar|MEDIUM
-packers/peid.yar|MEDIUM
 # HIGH
 # Used with documents to find if they have been crafted to leverage malicious code.
 maldocs/Maldoc_APT_OLE_JSRat.yar|HIGH
@@ -431,11 +428,15 @@ email/attachment.yar # detects all emails with attachments
 email/image.yar # detects all emails with images
 email/urls.yar # detects all emails with urls
 crypto/crypto_signatures.yar # detects all files which are encrypted
+# These files use module includes not supported by ClamAV
+packers/packer_compiler_signatures.yar
+packers/packer.yar
+packers/peid.yar
+antidebug_antivm
 )
 
 declare -a yararulesproject_dbs_catagories=(
 #LOW
-antidebug_antivm|LOW
 cve_rules|LOW
 exploit_kits|LOW
 malware|LOW


### PR DESCRIPTION
modules/includes are not supported by ClamAV and lead to parsing errors and crashes.