### PR TITLE
Enforce HTTPS validation by default

### DIFF
--- a/config/user.conf
+++ b/config/user.conf
@@ -57,7 +57,7 @@
 user_configuration_complete="yes"
 
 # Enforce HTTPS validation
-# Uncomment the following line to ignore SSL errors leading to insecure transfers
+# Disable the following line to ignore SSL errors leading to insecure transfers
 downloader_ignore_ssl="no"
 
 # Proxy Support

--- a/config/user.conf
+++ b/config/user.conf
@@ -56,6 +56,10 @@
 # Uncomment the following line to enable the script
 user_configuration_complete="yes"
 
+# Enforce HTTPS validation
+# Uncomment the following line to ignore SSL errors leading to insecure transfers
+downloader_ignore_ssl="no"
+
 # Proxy Support
 # If necessary to proxy database downloads, define the rsync, curl, wget, dig, hosr proxy settings here.
 #curl_proxy="--proxy http://username:password@proxy_host:proxy_port"


### PR DESCRIPTION
By default this script uses insecure HTTPS transfers. While there may be situations where this is required, it shouldn't be the default in 2020.

Placing it right above the proxy section in `user.conf` should make it visible enough if proxies prevent validation and installing the internal proxy CA to the trust store is not an option.