### PR TITLE
o added socks proxy support for rsync with help of netcat (nc) command

### DIFF
--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -2358,6 +2358,12 @@ if [ -n "$rsync_proxy" ] ; then
   export RSYNC_PROXY
 fi
 
+# If rsync connect program is defined in the config file, then export it for use. (to use netcat for socks tunnel)
+if [ -n "$rsync_connect_prog" ] ; then
+  RSYNC_CONNECT_PROG="$rsync_connect_prog"
+  export RSYNC_CONNECT_PROG
+fi
+
 # Create $current_dbsfiles containing lists of current and previously active 3rd-party databases
 # so that databases and/or backup files that are no longer being used can be removed.
 current_tmp="${work_dir_work_configs}/current-dbs.tmp"

--- a/config/user.conf
+++ b/config/user.conf
@@ -62,6 +62,7 @@ user_configuration_complete="yes"
 #dig_proxy="@proxy_host -p proxy_host:proxy_port"
 #host_proxy="@proxy_host" #does not support port
 #rsync_proxy="username:password@proxy_host:proxy_port"
+#rsync_connect_prog="nc -X 5 -x socksproxy_host:socksproxy_port %H 873"
 #wget_proxy="-e http_proxy=http://username:password@proxy_host:proxy_port -e https_proxy=https://username:password@proxy_host:proxy_port"
 
 # https://eXtremeSHOK.com ######################################################


### PR DESCRIPTION
I've added support to use rsync over socks proxy.
This patch sets the environment variabe RSYNC_CONNECT_PROG for rsync command, so rsync can use the netcat binary for the tcp connection. 