### PR TITLE
Update os.centos7-cpanel.conf

### DIFF
--- a/config/os/os.centos7-cpanel.conf
+++ b/config/os/os.centos7-cpanel.conf
@@ -30,5 +30,7 @@ clamd_pid="/run/clamd.pid"
 clamd_restart_opt="systemctl restart clamd"
 
 clamd_socket="/var/clamd"
+clamscan_bin="/usr/local/cpanel/3rdparty/bin/clamscan"
+
 
 # https://eXtremeSHOK.com ######################################################


### PR DESCRIPTION
fix for clamscan binary (clamscan_bin) not found.