### PR TITLE
Fix MalwarePatrol free DB download

### DIFF
--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -2582,12 +2582,12 @@ fi
 ############################################################################################
 if [ "$malwarepatrol_enabled" == "yes" ] ; then
     # Set the variables for MalwarePatrol
-    if [ "$malwarepatrol_product_code" != "8" ] ; then
-        # assumption, free product code is always 8 (non-free product code is never 8)
+    if [ "$malwarepatrol_product_code" != "32" ] ; then
+        # assumption, free product code is always 32 (non-free product code is never 32)
         malwarepatrol_free="no"
     fi
     if [ "$malwarepatrol_free" == "yes" ] ; then
-      malwarepatrol_product_code="8"
+      malwarepatrol_product_code="32"
       malwarepatrol_list="clamav_basic"
     else
       if [ -z $malwarepatrol_list ] ; then
@@ -2595,7 +2595,7 @@ if [ "$malwarepatrol_enabled" == "yes" ] ; then
       fi
       if [ -z $malwarepatrol_product_code ] ; then
         # Not sure, it may be better to return an error.
-        malwarepatrol_product_code=8
+        malwarepatrol_product_code=32
       fi
     fi
     if [ -z "$malwarepatrol_db" ] ; then

--- a/config/master.conf
+++ b/config/master.conf
@@ -77,9 +77,9 @@ log_file_name="clamav-unofficial-sigs.log"
 # 5. In the download URL, you will see 3 parameters: receipt, product and list, enter them in the variables below.
 
 malwarepatrol_receipt_code="YOUR-RECEIPT-NUMBER"
-malwarepatrol_product_code="8"
+malwarepatrol_product_code="32"
 malwarepatrol_list="clamav_basic" # clamav_basic or clamav_ext
-# if the malwarepatrol_product_code is not 8,
+# if the malwarepatrol_product_code is not 32,
 # the malwarepatrol_free is set to no (non-free)
 # set to no to enable the commercial subscription url,
 malwarepatrol_free="yes"

--- a/config/user.conf
+++ b/config/user.conf
@@ -31,8 +31,8 @@
 # set to no to enable the commercial subscription url
 #malwarepatrol_free="yes"
 #malwarepatrol_list="clamav_basic" # clamav_basic or clamav_ext
-# if the malwarepatrol_product_code is not 8 the malwarepatrol_free is set to no (non-free)
-#malwarepatrol_product_code="8"
+# if the malwarepatrol_product_code is not 32 the malwarepatrol_free is set to no (non-free)
+#malwarepatrol_product_code="32"
 #malwarepatrol_receipt_code="YOUR-RECEIPT-NUMBER"
 #malwarepatrol_db="malwarepatrol.db"
 


### PR DESCRIPTION
Free product code changed from 8 to 32 according to MalwarePatrol docs:

"Use 32 if you have a Free Guard account, 34 for Basic Defense monthly, 33 for Basic Defense yearly,
and 37 for Basic Defense EDU/Contributor (Free) accounts."