### PR TITLE
Updated Yara rule website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Usage of free URLhaus Database: <https://urlhaus.abuse.ch>
 
 ### Yara-Rules Project Support (as of June 2015, updated January 2020)
 
-Usage of free Yara-Rules Project: <https://yara-rules.github.io/blog/>
+Usage of free Yara-Rules Project: <http://yararules.com>
 
 * Enabled by default
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Usage of free URLhaus Database: <https://urlhaus.abuse.ch>
 
 ### Yara-Rules Project Support (as of June 2015, updated January 2020)
 
-Usage of free Yara-Rules Project: <http://yararules.com>
+Usage of free Yara-Rules Project: <https://yara-rules.github.io/blog/>
 
 * Enabled by default
 


### PR DESCRIPTION
Updated Yara rule website link on the README because the original link seems to direct to a weird website. Probably the domain got bought. 