### PR TITLE
MalwarePatrol Google Drive Whitelisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Usage of free URLhaus Database: <https://urlhaus.abuse.ch>
 
 ### Yara-Rules Project Support (as of June 2015, updated January 2020)
 
-Usage of free Yara-Rules Project: <https://yara-rules.github.io/blog/>
+Usage of free Yara-Rules Project: <http://yararules.com>
 
 * Enabled by default
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Usage of free URLhaus Database: <https://urlhaus.abuse.ch>
 
 ### Yara-Rules Project Support (as of June 2015, updated January 2020)
 
-Usage of free Yara-Rules Project: <http://yararules.com>
+Usage of free Yara-Rules Project: <https://yara-rules.github.io/blog/>
 
 * Enabled by default
 

--- a/clamav-unofficial-sigs.sh
+++ b/clamav-unofficial-sigs.sh
@@ -2601,6 +2601,9 @@ if [ "$malwarepatrol_enabled" == "yes" ] ; then
     if [ -z "$malwarepatrol_db" ] ; then
         malwarepatrol_db="malwarepatrol.db"
     fi
+    if [ -z "$malwarepatrol_whitelist_googledrive" ] ; then
+        malwarepatrol_whitelist_googledrive="no"
+    fi
     malwarepatrol_url="${malwarepatrol_url}?receipt=${malwarepatrol_receipt_code}&product=${malwarepatrol_product_code}&list=${malwarepatrol_list}"
 elif [ "$remove_disabled_databases" == "yes" ] ; then
     malwarepatrol_remove_dbs=( "malwarepatrol.db" )
@@ -3792,6 +3795,11 @@ if [ "$malwarepatrol_enabled" == "yes" ] ; then
 
             xshok_file_download "${work_dir_malwarepatrol}/${malwarepatrol_db}" "${malwarepatrol_url}"
 
+            #Check if Google Drive entries need to be removed
+            if [ "$malwarepatrol_whitelist_googledrive" == "yes" ] ; then
+                sed -i '/\=68747470733a2f2f64726976652e676f6f676c652e636f6d$/d' "${work_dir_malwarepatrol}/${malwarepatrol_db}"
+            fi
+            
             ret="$?"
             if [ "$ret" -eq 0 ] ; then
               loop="1"

--- a/config/master.conf
+++ b/config/master.conf
@@ -84,7 +84,7 @@ malwarepatrol_list="clamav_basic" # clamav_basic or clamav_ext
 # set to no to enable the commercial subscription url,
 malwarepatrol_free="yes"
 malwarepatrol_db="malwarepatrol.db"
-
+malwarepatrol_whitelist_googledrive="no"
 
 # =========================
 # Malware Expert : https://www.Malware Expert

--- a/config/user.conf
+++ b/config/user.conf
@@ -35,6 +35,7 @@
 #malwarepatrol_product_code="8"
 #malwarepatrol_receipt_code="YOUR-RECEIPT-NUMBER"
 #malwarepatrol_db="malwarepatrol.db"
+#malwarepatrol_whitelist_googledrive="no"
 
 #securiteinfo_authorisation_signature="YOUR-SIGNATURE-NUMBER"
 # Enable if you have a commercial/premium/non-free subscription


### PR DESCRIPTION
This pull adds a parameter in the configs to allow the script to include or exclude Google Drive based entries for MalwarePatrol. 

malwarepatrol_whitelist_googledrive="yes"
This will remove Google Drive based entries from the database based on https://github.com/extremeshok/clamav-unofficial-sigs/issues/381

malwarepatrol_whitelist_googledrive="no"
Default and current behavior, do nothing to the database that is downloaded from MalwarePatrol. 

Feel free to edit to your liking of course, this is a draft. 