### PR TITLE
define clam_user and clam_group so xshok_mkdir_ownership does not fail out of the box

### DIFF
--- a/config/master.conf
+++ b/config/master.conf
@@ -22,8 +22,8 @@
 # Set the appropriate ClamD user and group accounts for your system.
 # If you do not want the script to set user and group permissions on
 # files and directories, comment the next two variables.
-#clam_user="clamav"
-#clam_group="clamav"
+clam_user="clamav"
+clam_group="clamav"
 
 # If you do not want the script to change the file mode of all signature
 # database files in the ClamAV working directory to 0644 (-rw-r--r--):

--- a/config/user.conf
+++ b/config/user.conf
@@ -16,6 +16,12 @@
 # SEE MASTER.CONF FOR CONFIG EXPLANATIONS
 ################################################################################
 
+# Set the appropriate ClamD user and group accounts for your system.
+# If you do not want the script to set user and group permissions on
+# files and directories, comment the next two variables.
+#clam_user="clamav"
+#clam_group="clamav"
+
 # Values in this file will always override those in the master.conf and os.conf files.
 # This is useful to specify your authorisation/receipt codes and to always force certain options.
 # Please note, it is your responsibility to manage the contents of this file.


### PR DESCRIPTION
xshok_mkdir_ownership  expects clam_user and clam_group to be defined. Just define them by default and note them in the user config as well.
