### PR TITLE
remove percentages from comments

### DIFF
--- a/config/master.conf
+++ b/config/master.conf
@@ -341,11 +341,11 @@ declare -a interserver_dbs=(
 ## REQUIRED, Do NOT disable
 whitelist.fp|REQUIRED  # found to be false positive malware
 # LOW
-interserver256.hdb|LOW	# 100% known malware sha256 format
+interserver256.hdb|LOW	# 100 Percent known malware sha256 format
 # MEDIUM
 interservertopline.db|MEDIUM  # inserts into files, manual cleaning HEX
 # HIGH
-shell.ldb|HIGH  # 99.9% known malware using logical signatures
+shell.ldb|HIGH  # 99.9 Percent known malware using logical signatures
 ) #END Malware Expert DATABASES
 
 # ========================


### PR DESCRIPTION
in response to #405 this change to master.conf seems to fix the issue - it appears to be the "%" symbol in the comments. Need 3rd party confirmation though.