### PR TITLE
Remove deprecated bank_rule.yar

### DIFF
--- a/config/master.conf
+++ b/config/master.conf
@@ -428,7 +428,6 @@ cve_rules/CVE-2017-11882.yar|MEDIUM
 cve_rules/CVE-2018-20250.yar|MEDIUM
 cve_rules/CVE-2018-4878.yar|MEDIUM
 # Identification of malicious e-mails.
-email/bank_rule.yar|MEDIUM
 email/EMAIL_Cryptowall.yar|MEDIUM
 email/Email_fake_it_maintenance_bulletin.yar|MEDIUM
 email/Email_quota_limit_warning.yar|MEDIUM


### PR DESCRIPTION
it has been removed in upstream Yara rules, and so we currently always throw warning:

> WARNING: Failed connection to https://raw.githubusercontent.com/Yara-Rules/rules/master - SKIPPED yararulesproject bank_rule.yar update

PR is made against `dev` branch.

Also, it would be good to finally publish `dev` branch to `master` and make a release, as there are few other bugs pending which users keep reporting (like https://github.com/extremeshok/clamav-unofficial-sigs/pull/400, https://github.com/extremeshok/clamav-unofficial-sigs/pull/414, etc)