### PR TITLE
docker-publish: build the multi-arch image from the debian clamav base

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,6 +46,10 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          # the alpine clamav/clamav image only publishes amd64, the official
+          # debian variant is the multi-arch (amd64/arm64) image
+          build-args: |
+            BASE_IMAGE=clamav/clamav-debian:stable
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Debian, Ubuntu, Raspbian, RHEL (Rocky Linux, AlmaLinux, CentOS and clones), Fedo
 
 ### Docker
 
-Official image built on `clamav/clamav:stable`, see the [docker guide](https://github.com/extremeshok/clamav-unofficial-sigs/blob/master/guides/docker.md)
+Official multi-arch image built on the official ClamAV image, see the [docker guide](https://github.com/extremeshok/clamav-unofficial-sigs/blob/master/guides/docker.md)
 
 ```bash
 # all-in-one: clamd + freshclam + unofficial signatures

--- a/guides/docker.md
+++ b/guides/docker.md
@@ -1,6 +1,6 @@
 # Docker guide for clamav-unofficial-sigs
 
-The container image is built on the official `clamav/clamav:stable` image, so it always carries a current ClamAV for signature integrity testing.
+The container image is built on the official ClamAV image (the published multi-arch image uses `clamav/clamav-debian:stable`, the only official variant with amd64 and arm64 manifests), so it always carries a current ClamAV for signature integrity testing.
 
 ## Quick start (all-in-one)
 


### PR DESCRIPTION
Follow-up to #429: the first docker-publish run on master failed because the alpine `clamav/clamav:stable` image only publishes a linux/amd64 manifest ("no match for platform in manifest" on linux/arm64). The official debian variant `clamav/clamav-debian:stable` is the multi-arch (amd64/arm64) image, and the Dockerfile already supports it via the `BASE_IMAGE` build-arg — the publish workflow now uses it. Docs adjusted to match.

---
_Generated by [Claude Code](https://claude.ai/code/session_012rt4hZ796Yna2DFuwhKZBf)_