### PR TITLE
Add a release workflow and the 8.0.0 release notes

### DIFF
--- a/.github/release-notes/8.0.0.md
+++ b/.github/release-notes/8.0.0.md
@@ -1,0 +1,55 @@
+# Version 8.0.0
+
+First release since 7.2.5 (March 2021). This release consolidates the unreleased `dev` branch, every applicable community PR, fixes for the long-standing open issues, and modernises the project for the current ClamAV and signature-source landscape. Verified against **ClamAV 1.4.4 (LTS)** and **1.5.3 (stable)** with real end-to-end runs.
+
+## Highlights
+
+* **Modern ClamAV (1.x) support** — robust version parsing/comparison (`1.4.x`, `1.5.x`, `0.103.x`, `-rc`/`-devel`/`+dfsg` suffixes) for the yara gate, self-update and config checks
+* **Official Docker image** — `ghcr.io/extremeshok/clamav-unofficial-sigs`, built on the official ClamAV image, all-in-one and updater-sidecar modes, one-shot arg passthrough, an honest healthcheck (detects never-completed, failed, and stalled update loops), multi-arch (amd64/arm64) with weekly rebuilds — thanks @mnalis for the original Dockerfile concept. See guides/docker.md
+* **urlhaus finally works** — two root causes fixed: the missing `dbs-uh` work directory / `urlhausy` typo (dev branch + #420/#414/#400/#402, thanks @robert-scheck @Devstellar @amartin-git @stimpy23), AND urlhaus was missing from the current-databases tracking list, so the cleanup pass deleted `urlhaus.ndb` right after each install (#398)
+* **Two new signature sources** (verified loading in ClamAV 1.4.4/1.5.3, disabled by default): **ditekshen/detection** (#396) and **twinclams** (#397, actively updated by Splunk/TwinWave); disabled optional sources never delete same-named databases installed by other means
+* **rsync is now optional** for https-only setups (#366) — internal cp fallback, with a clear error when sanesecurity (which genuinely needs rsync) is enabled without it
+* **~380 lines of copy-paste removed** — per-source test-and-install logic unified into shared helpers; fixed bugs hidden in the duplication (all `keep_db_backup` backups collapsed onto one `_file-bak` file — including the sanesecurity copy; LMD restorecon on the wrong file)
+* **GitHub Actions CI** replaces defunct Travis-CI/Code Climate: shellcheck (clean with zero CLI excludes), config-parse smoke matrix with real clamav, every os config parse-tested, an upgrade-path guard (the 7.2.5 parser must parse the new master.conf), a Docker build + smoke job with a real signature download, and a weekly source-liveness probe
+
+## Community PRs merged
+
+#427 rsync wildcards for additional dbs (@amulet1) · #422 stray backslash (@code-chicken) · #415 bank_rule.yar removal (@mnalis) · #404 clam_user/group defaults (@VVelox) · #408 percent signs (@stevenhardey) · #418 guide links (@sammcj) · plus the dev branch (#389 #390 #393 #394 #395)
+
+**#405 was reviewed and rejected**: the script builds `${urlhaus_url}/${db_file}`, so the existing base URL already produces the correct `.../downloads/urlhaus.ndb`; applying #405 would double the filename.
+
+## Bug fixes (issue refs)
+
+* #388 multiple CLI options were ignored (misplaced `break`s)
+* #403/#424 config parser stripped quotes via `xargs` on Solaris → `--reload: command not found`; plus a clamd-socket `RELOAD` fallback (perl/socat/nc) when `clamd_reload_opt` fails
+* #383 portable `stat` (BSD `%OLp`) for upgrade permission preservation
+* #417 `/opt/homebrew` config dir for Apple Silicon; missing-config error no longer fires before `-c/--config` is parsed; `-c` now derives the config dir for `--upgrade`
+* #411 `-w` whitelisting produced `Name;Engine` garbage for ldb signatures
+* #381 MalwarePatrol lines >8189 chars are filtered (single pass, atomic); Google-Drive filter no longer clobbers the download status and is BSD-portable
+* #398 urlhaus removed by cleanup after every install (missing tracking entry)
+* Sanesecurity GPG key setup no longer runs (and aborts the whole run on failure) when sanesecurity is disabled
+* wget downloads with a renamed output file use a temp file — a failed transfer no longer truncates the last good copy; LMD version checks now work on wget-only hosts
+* os.alpine.conf executed `clamdscan --reload` during config parsing (stray unquoted line)
+* cron minute off-by-one; wget symlink/cd workarounds removed; `work_dir_linuxmalwaredetect` override fixed; #427 wildcard loop no longer clamscan-tests the literal glob on no-match
+
+## Sources
+
+* **New: ditekshen/detection** (`clamav.ldb`, `indicator_rmm.ldb`) — disabled by default (#396)
+* **New: twinclams** (`twinclams.hdb`, `twinclams.ldb`, `twinwave.ign2` whitelist) — disabled by default (#397)
+* SecuriteInfo premium: added `securiteinfo.pdb`, `securiteinfo.wdb`, `securiteinfo.yara` (#416)
+* **yararulesproject is now DISABLED by default** (#406) — upstream repo unmaintained, some rules crash modern clamav; re-enabling prints a deprecation warning
+* OITC/winnow, MiscreantPunch, RookSecurity annotated as dead upstreams (files still ship via Sanesecurity mirrors); MalwarePatrol free product code now defaults to 32
+
+## OS / packaging / docs
+
+* New `os.rhel.conf` (RHEL/Rocky/Alma 8-10) + guides/rhel.md, new `os.macos.applesilicon.conf`, new `os.docker.conf`
+* `os.debian.conf` / `os.ubuntu.conf` refreshed (modern `/run` paths, `clamd_reload_opt`, #392); EOL configs marked deprecated in comments, kept for packagers
+* `systemd/clamd.scan.service`: legacy `.include` (removed in systemd 240) replaced with drop-in override instructions
+* README: false-positive/whitelisting FAQ (answers #409 #399 #413 #380, incl. the yara-cannot-be-ignored-via-ign2 ClamAV limitation), Docker quick start, refreshed OS list
+* user.conf: examples for optional sources and a security-hardening section
+
+## Upgrade notes
+
+* Existing v7.x installs upgrade in place: `clamav-unofficial-sigs.sh --upgrade` fetches this release and migrates the config. `config_version` is now **100**; `minimum_required_config_version` intentionally stays **96** so v7.x installs still start and can upgrade.
+* Users with `remove_disabled_databases="yes"` (default) will have their yararulesproject files removed on the next run — intended, but worth calling out.
+* Docker users: `docker pull ghcr.io/extremeshok/clamav-unofficial-sigs:8.0.0` (also `:latest`).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+###################
+# This is property of eXtremeSHOK.com
+# You are free to use, modify and distribute, however you may not remove this notice.
+# Copyright (c) Adrian Jon Kriel :: admin@extremeshok.com
+# License: BSD (Berkeley Software Distribution)
+##################
+name: Release
+
+on:
+  push:
+    tags: ['*.*.*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to publish a GitHub release for'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Publish GitHub release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 ; then
+            echo "Release $TAG already exists, nothing to do"
+            exit 0
+          fi
+          # release notes live in the repo, fall back to the auto-generated ones
+          notes=".github/release-notes/${TAG}.md"
+          if [ -f "$notes" ] ; then
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --verify-tag --title "$TAG" --notes-file "$notes"
+          else
+            gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --verify-tag --title "$TAG" --generate-notes
+          fi


### PR DESCRIPTION
Adds `.github/workflows/release.yml`, which publishes a GitHub release for a pushed `*.*.*` tag (or a tag named via manual dispatch). Notes are taken from `.github/release-notes/<tag>.md` when that file exists, otherwise auto-generated. Existing releases are left untouched, so re-runs are safe.

Also adds `.github/release-notes/8.0.0.md` with the final 8.0.0 release notes, so future releases keep their notes in the repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_012rt4hZ796Yna2DFuwhKZBf)_