### PR TITLE
release workflow: sync notes of an existing release from the in-repo notes file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 ; then
-            echo "Release $TAG already exists, nothing to do"
-            exit 0
-          fi
           # release notes live in the repo, fall back to the auto-generated ones
           notes=".github/release-notes/${TAG}.md"
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1 ; then
+            if [ -f "$notes" ] ; then
+              echo "Release $TAG already exists, syncing notes from ${notes}"
+              gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --title "$TAG" --notes-file "$notes"
+            else
+              echo "Release $TAG already exists, nothing to do"
+            fi
+            exit 0
+          fi
           if [ -f "$notes" ] ; then
             gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --verify-tag --title "$TAG" --notes-file "$notes"
           else


### PR DESCRIPTION
When a release already exists for the tag, the workflow now updates its title and body from `.github/release-notes/<tag>.md` instead of doing nothing, so the in-repo notes file stays the single source of truth. Dispatching it for `8.0.0` replaces the current release body (the raw PR #429 text, which still carries the pre-merge maintainer checklists) with the cleaned user-facing notes.

---
_Generated by [Claude Code](https://claude.ai/code/session_012rt4hZ796Yna2DFuwhKZBf)_