### PR TITLE
release workflow: checkout the dispatch ref so notes can be newer than the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,10 @@ jobs:
     name: Publish GitHub release
     runs-on: ubuntu-latest
     steps:
+      # no explicit ref: a tag push checks out the tag, a manual dispatch
+      # checks out the branch it was dispatched on, so the notes file can be
+      # newer than the tag it describes
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag || github.ref_name }}
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The manual dispatch path checked out `inputs.tag`, so a notes file committed after the tag (the 8.0.0 case) was invisible and the notes-sync no-op'd. Dropping the explicit ref keeps tag pushes checking out the tag while manual dispatches check out the branch they were dispatched on, where the current notes live.
